### PR TITLE
Add github action for acceptance checks

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,0 +1,21 @@
+name: acceptance
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name: Install pipenv
+        run: pip install pipenv
+      - name: Install dependencies
+        run: PIPENV_VERBOSITY=-1 make pipenv-dev
+      - name: Run acceptance check
+        run: PIPENV_VERBOSITY=-1 make commit-acceptance


### PR DESCRIPTION
The workflow is using python 3.8 and is running on ubuntu latest.
The phases of locking and checking are split in order to have more fine
data about the length of respective phases.
Reslolves #1 