### PR TITLE
Use groupified versioning in Templates

### DIFF
--- a/testsuite/resources/apicast.yml
+++ b/testsuite/resources/apicast.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: 3scale-gateway

--- a/testsuite/resources/modular_apicast/apicast_example_policy.yml
+++ b/testsuite/resources/modular_apicast/apicast_example_policy.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
 name: "apicast-example-policy"

--- a/testsuite/resources/on_failed_policy/apicast_failing_policy.yml
+++ b/testsuite/resources/on_failed_policy/apicast_failing_policy.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
 name: "apicast-failing-policy"

--- a/testsuite/resources/service_mesh/httpbin.yaml
+++ b/testsuite/resources/service_mesh/httpbin.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: servicemesh-httpbin

--- a/testsuite/resources/service_mesh/policy-1.1.yaml
+++ b/testsuite/resources/service_mesh/policy-1.1.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: 3scale-adapter-rhsso-policy

--- a/testsuite/resources/service_mesh/policy.yaml
+++ b/testsuite/resources/service_mesh/policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: 3scale-adapter-rhsso-policy

--- a/testsuite/resources/tls/httpbin_go.yaml
+++ b/testsuite/resources/tls/httpbin_go.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: go-httpbin


### PR DESCRIPTION
- Recent versions of `oc` have started throwing warnings about using ungroupified versions (`v1` instead of `template.openshift.io/v1`) when using new-app, they are warnings for now but they might become unsupported later.
- Other usages of such versioning were not causing the warnings to I didn't change them (notably, inside the templates)