### PR TITLE
Improve performance for on_failed tests

### DIFF
--- a/testsuite/tests/apicast/policy/on_failed/test_onfailed.py
+++ b/testsuite/tests/apicast/policy/on_failed/test_onfailed.py
@@ -53,7 +53,7 @@ def test_on_failed_policy(application, status_code):
     Sends request to apicast and check that the returned code
     is the expected one as per `status_code`
     """
-    api_client = application.api_client()
+    api_client = application.api_client(disable_retry_status_list=(503,))
 
     response = api_client.get("/")
     assert response.status_code == status_code

--- a/testsuite/tests/apicast/policy/on_failed/test_onfailed.py
+++ b/testsuite/tests/apicast/policy/on_failed/test_onfailed.py
@@ -2,6 +2,7 @@
 Create a service with a non existent policy in the chain
 and tests that on failed policy returns the correct error code.
 """
+import backoff
 import pytest
 
 from testsuite import rawobj
@@ -48,6 +49,14 @@ def status_code(chain_name, on_failed_configuration) -> int:
     return on_failed_configuration.get("error_status_code", 503)
 
 
+@backoff.on_predicate(backoff.fibo,
+                      lambda response: response.headers.get("server") != "openresty",
+                      max_tries=5)
+def make_request(api_client):
+    """Make request to the product and retry if the response isn't from APIcast """
+    return api_client.get("/")
+
+
 def test_on_failed_policy(application, status_code):
     """
     Sends request to apicast and check that the returned code
@@ -55,5 +64,6 @@ def test_on_failed_policy(application, status_code):
     """
     api_client = application.api_client(disable_retry_status_list=(503,))
 
-    response = api_client.get("/")
+    response = make_request(api_client)
     assert response.status_code == status_code
+    assert response.headers["server"] == "openresty"

--- a/testsuite/tests/apicast/policy/on_failed/test_onfailed_custom_policy.py
+++ b/testsuite/tests/apicast/policy/on_failed/test_onfailed_custom_policy.py
@@ -93,7 +93,7 @@ def test_on_failed(build_images, application, return_code):
     to on_failed policy configuration.
     build_images is requested but not used to trigger the build of the image with the custom policy
     """
-    api_client = application.api_client()
+    api_client = application.api_client(disable_retry_status_list=(503,))
 
     response = api_client.get("/")
     assert response.status_code == return_code

--- a/testsuite/tests/apicast/policy/on_failed/test_onfailed_custom_policy.py
+++ b/testsuite/tests/apicast/policy/on_failed/test_onfailed_custom_policy.py
@@ -2,7 +2,7 @@
 Build an apicast image containing a custom policies that fails during execution
 and tests that on failed policy returns the correct error code.
 """
-
+import backoff
 import pytest
 import importlib_resources as resources
 
@@ -86,6 +86,14 @@ def return_code(request) -> int:
     return on_failed_conf.get("error_status_code", 503)
 
 
+@backoff.on_predicate(backoff.fibo,
+                      lambda response: response.headers.get("server") != "openresty",
+                      max_tries=5)
+def make_request(api_client):
+    """Make request to the product and retry if the response isn't from APIcast """
+    return api_client.get("/")
+
+
 # pylint: disable=unused-argument
 def test_on_failed(build_images, application, return_code):
     """
@@ -95,5 +103,6 @@ def test_on_failed(build_images, application, return_code):
     """
     api_client = application.api_client(disable_retry_status_list=(503,))
 
-    response = api_client.get("/")
+    response = make_request(api_client)
     assert response.status_code == return_code
+    assert response.headers["server"] == "openresty"


### PR DESCRIPTION
* The 503 errors are by default retried, this removes the retrying.
@palmieric WDYT?