### PR TITLE
updated mail tests to be run in parallel

### DIFF
--- a/testsuite/tests/system/messages/mail_templates.yml
+++ b/testsuite/tests/system/messages/mail_templates.yml
@@ -25,7 +25,7 @@ subject_templates:
       Body: '----==_mimepart_.+Content-Type: text/plain; charset=UTF-8Content-Transfer-Encoding:
       7bitDear <username>,A new application subscribed to the <aplan> plan on the
       <service> service of the <test_group> account.Application details:  Name:
-      API signup  Description: API signupTo view application, follow this link: https://3scale-admin.<threescale_superdomain>/apiconfig/services/[0-9]+/applications/[0-9]+You
+      API signup  Description: API signupTo view application, follow this link: https://3scale-admin.<threescale_superdomain>/p/admin/applications/[0-9]+You
       are receiving this because you subscribed to this notification.View notification
       preferences on https://3scale-admin.<threescale_superdomain>/p/admin/user/notification_preferences----==_mimepart_.+Content-Type:
       text/html; charset=UTF-8Content-Transfer-Encoding: quoted-printable<!DOCTYPE
@@ -33,7 +33,7 @@ subject_templates:
       &#39;Lucida Grande&#39;, verdana, sans-serif;"><p>Dear <username>,</p><p>A new
       application subscribed to the <aplan> plan on the <service> service
       of the <test_group> account.</p><p><b>Application details:</b></p><ul><li><b>Name:</b>
-      API signup</li><li><b>Description:</b> API signup</li></ul><p><a href=3D"https://3scale-admin.<threescale_superdomain>/apiconfig/services/[0-9]+/applications/[0-9]+">View
+      API signup</li><li><b>Description:</b> API signup</li></ul><p><a href=3D"https://3scale-admin.<threescale_superdomain>/p/admin/applications/[0-9]+">View
       new application in your 3scale Admin Portal</a></p><p>=E2=80=94<br />You
       are receiving this because you subscribed to this notification.<br />View notification
       preferences on <a href=3D"https://3scale-admin.<threescale_superdomain>/p/admin/user/notification_preferences">3scale.net</a>

--- a/testsuite/tests/system/messages/test_account_message.py
+++ b/testsuite/tests/system/messages/test_account_message.py
@@ -10,19 +10,23 @@ import backoff
 def assert_message_received(mailhog, text):
     """Resilient test on presence of expected message with retry"""
     messages = mailhog.messages()
-    assert any(m for m in messages["items"] if text in m["Content"]["Body"])
+    ids = list(m["ID"] for m in messages["items"] if text in m["Content"]["Body"])
+    assert len(ids) == 1, f"Expected 1 mail, found {len(ids)}"
+    return ids
 
 
 def test_account_will_receive_email(mailhog_client, threescale, account):
     """
     Sends a message to an account
     Assert that a corresponding email has been sent
+    Delete the corresponding email after the check
+    It is not possible to delete email on failed tests because
+    the list returned by assert_message_received would be empty
     """
-    test_message_body = "body_test_account_will_receive_email"
-
-    mailhog_client.delete()
+    test_message_body = f"body_test_account_will_receive_email+{account.entity['org_name']}"
 
     threescale.threescale_client.accounts\
         .send_message(entity_id=account.entity_id, body=test_message_body)
 
-    assert_message_received(mailhog_client, test_message_body)
+    ids = assert_message_received(mailhog_client, test_message_body)
+    mailhog_client.delete(ids)


### PR DESCRIPTION
This PR is meant to remove the need to delete all the emails in mailhog before and after a test run so now tests can be performed in parallel.