### PR TITLE
New (simpler) versioning scheme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ release: VERSION-required Pipfile.lock testsuite/resources/apicast.yml
 	git add -f Pipfile.lock
 	git add testsuite/resources/apicast.yml
 	git commit -m"`git rev-parse --abbrev-ref HEAD`"
-	git tag -a "`git rev-parse --abbrev-ref HEAD|cut -c2-`" -m"`git rev-parse --abbrev-ref HEAD`"
+	git tag -a "`git rev-parse --abbrev-ref HEAD|cut -c9-`" -m"`git rev-parse --abbrev-ref HEAD`"
 	git rm --cached Pipfile.lock
 	git commit -m"Unfreeze Pipfile.lock after release"
 

--- a/scripts/docker-tags
+++ b/scripts/docker-tags
@@ -10,50 +10,39 @@ from packaging.version import Version, InvalidVersion
 tags = run(["git", "tag"], check=False, encoding="utf-8", stdout=PIPE)
 tags = tags.stdout.split()
 
-version_str = open("VERSION").read().strip()
-version = Version(version_str)
+version = Version(open("VERSION").read().strip())
 
 versions = []
 for tag in tags:
     try:
-        versions.append(Version(tag))
+        versions.append(Version(tag[1:]))
     except InvalidVersion:
         pass
-latest = sorted(
-    versions,
-    key=lambda v: v.release + (v.post, v.pre[1] if v.pre else 20000000))[-1]
+latest = sorted(versions)[-1])
 
 just_one = "-1" in sys.argv
 
-
-def vstr(ver):
-    return f"{ver.base_version}-r{ver.post}"
-
-
 def docker_tags(version, latest, just_one):
+    version = str(version)  # X.Y.Z.R
     tags = [version]
     if just_one:
         return tags
-    tags.append(version.split("-")[0])
+    tags.append(version.rsplit(".", 1)[0])  # X.Y.Z
     if latest:
-        tags.append(version.rsplit(".", 1)[0])
+        tags.append(version.rsplit(".", 2)[0])  # X.Y
         tags.append(version.split(".")[0])
         tags.append("latest")
     return tags
 
 
-if version_str in tags:
-    print(" ".join(docker_tags(version_str, latest == version, just_one)))
-    sys.exit(0)
-
-if version_str == vstr(latest):
-    print(str(latest).replace(".post", "-r"))
+if f"v{version}" in tags:
+    print(" ".join(docker_tags(version, latest == version, just_one)))
     sys.exit(0)
 
 rc = 1
-current = f"{version.base_version}rc{rc}-r{version.post}"
+current = f"v{version}rc{rc}"
 
 while current in tags:
     rc += 1
-    current = f"{version.base_version}rc{rc}-r{version.post}"
+    current = f"{version}rc{rc}"
 print(current)

--- a/scripts/make-next-release
+++ b/scripts/make-next-release
@@ -15,18 +15,18 @@ tags = run(["git", "tag"], check=False, encoding="utf-8", stdout=PIPE)
 tags = tags.stdout.split()
 
 revision=1
-nextver=f"{version}-r{revision}"
-while nextver in tags:
+nextver=f"{version}.{revision}"
+while f"v{nextver}" in tags:
     revision += 1
-    nextver=f"{version}-r{revision}"
+    nextver=f"{version}.{revision}"
 
 rc=1
-nextver=f"{version}rc{rc}-r{revision}"
-while nextver in tags:
+nextver=f"{version}.{revision}rc{rc}"
+while f"v{nextver}" in tags:
     rc += 1
-    nextver=f"{version}rc{rc}-r{revision}"
+    nextver=f"{version}.{revision}rc{rc}"
 
 with open("VERSION", "w") as s:
-    s.write(f"{version}-r{revision}\n")
+    s.write(f"{version}.{revision}\n")
 
-run(["git", "checkout", "-b", f"v{version}rc{rc}-r{revision}"], check=True)
+run(["git", "checkout", "-b", f"release-v{version}.{revision}rc{rc}"], check=True)


### PR DESCRIPTION
Use "2.2.0.3" instead of "2.2.0-r3". This makes version handling
slightly easier. Also standardized v* tag name is used now.