### PR TITLE
Toolbox service account

### DIFF
--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -326,7 +326,7 @@ def user(custom_user, account, request, testconfig, configuration):
     return usr
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def custom_user(request, testconfig):  # pylint: disable=unused-argument
     """Parametrized custom User
 

--- a/testsuite/tests/toolbox/test_account.py
+++ b/testsuite/tests/toolbox/test_account.py
@@ -1,0 +1,44 @@
+"""Tests for Services Toolbox feature"""
+
+import re
+
+import pytest
+
+from testsuite.toolbox import toolbox
+
+
+@pytest.fixture(scope="module")
+def create_cmd(threescale_src1):
+    """ Returns function of account command creation """
+
+    def _create_cmd(cmd, args=None):
+        args = args or ''
+        return f"account {cmd} {threescale_src1} {args}"
+
+    return _create_cmd
+
+
+def parse_find_command_out(output):
+    """Returns data from 'find' command output."""
+    return re.match(r"id => (\d+)\n\norg_name => ([^\n ]+)", output, re.MULTILINE).groups()
+
+
+def test_find_account_by_name(account, create_cmd):
+    """Run command 'account find'"""
+    ret = toolbox.run_cmd(create_cmd('find', account['org_name']))
+    assert not ret['stderr']
+    (acc_id, org_name) = parse_find_command_out(ret['stdout'])
+    assert int(acc_id) == account['id']
+    assert org_name == account['org_name']
+
+
+def test_find_account_by_user(account, user, create_cmd):
+    """Run command 'account find'"""
+    # pylint: disable=unused-argument
+    for acc_user in account.users.list():
+        for attr in ['email', 'username']:
+            ret = toolbox.run_cmd(create_cmd('find', acc_user[attr]))
+            assert not ret['stderr']
+            (acc_id, org_name) = parse_find_command_out(ret['stdout'])
+            assert int(acc_id) == account['id']
+            assert org_name == account['org_name']

--- a/testsuite/tests/toolbox/test_service.py
+++ b/testsuite/tests/toolbox/test_service.py
@@ -86,6 +86,26 @@ def test_list2(empty_list, service, threescale, create_cmd):
     assert re.findall(to_cmp, ret['stdout'])
 
 
+def test_show2(threescale, create_cmd):
+    """Run command 'show' second service"""
+    # pylint: disable=unused-argument
+
+    ret = toolbox.run_cmd(create_cmd('show', out_variables['ser2_entity']['id']))
+    assert not ret['stderr']
+
+    to_cmp = "ID\tNAME\tSTATE\tSYSTEM_NAME\tEND_USER_REGISTRATION_REQUIRED\tBACKEND_VERSION\t"
+    to_cmp += "DEPLOYMENT_OPTION\tSUPPORT_EMAIL\tDESCRIPTION\tCREATED_AT\tUPDATED_AT"
+    assert re.findall(to_cmp, ret['stdout'])
+
+    service2 = out_variables['ser2_entity']
+    to_cmp = fr"{service2['id']}\t{service2['name']}\t{service2['state']}\t{service2['system_name']}\t"
+    # END_USER_REGISTRATION_REQUIRED will be removed because of https://issues.redhat.com/browse/THREESCALE-7916
+    to_cmp += fr"\(empty\)\t{service2['backend_version']}\t{service2['deployment_option']}\t"
+    to_cmp += fr"{service2['support_email']}\t{service2['description']}\t"
+    to_cmp += fr"{service2['created_at']}\t{service2['updated_at']}"
+    assert re.findall(to_cmp, ret['stdout'])
+
+
 def test_apply1(service, threescale, create_cmd):
     """Run command 'apply' to update first service"""
     # pylint: disable=unused-argument


### PR DESCRIPTION
- add tests for commands `service show` and `account find`
- fix scope of `custom_service` fixture