### PR TITLE
Change SelfManagedApicast to initialize the correct gateway for the environment

### DIFF
--- a/testsuite/configuration.py
+++ b/testsuite/configuration.py
@@ -73,7 +73,9 @@ class CommonConfiguration(ThreeScaleAuthDetails, OpenshiftRequirement, Certifica
 
 def call(method, **kwargs):
     """Calls method with only parameters it requires"""
-    expected = inspect.signature(method).parameters.keys()
+    # Due to SelfManaged overriding __new__, inspect cannot infer the expected variables from __new__
+    inspected_method = method.__init__ if inspect.isclass(method) else method
+    expected = inspect.signature(inspected_method).parameters.keys()
     return method(**{k: v for k, v in kwargs.items() if k in expected})
 
 

--- a/testsuite/gateways/__init__.py
+++ b/testsuite/gateways/__init__.py
@@ -47,8 +47,10 @@ def gateway(kind: Union[Type[Gateway], str] = None, staging: bool = True, **kwar
     configuration = settings["threescale"]["gateway"]["default"].copy()
     kind = kind or configuration["kind"]
     clazz = globals()[kind] if not inspect.isclass(kind) else kind  # type: ignore
-    name = kind.__name__ if inspect.isclass(kind) else kind  # type: ignore
+    if hasattr(clazz, "resolve_class"):
+        clazz = clazz.resolve_class()
 
+    name = clazz.__name__
     named_settings = {}
     if name in settings["threescale"]["gateway"]:
         named_settings = settings["threescale"]["gateway"][name]

--- a/testsuite/gateways/apicast/operator.py
+++ b/testsuite/gateways/apicast/operator.py
@@ -1,7 +1,7 @@
 """Apicast deployed with ApicastOperator"""
 import time
 
-from testsuite.capabilities import Capability
+from testsuite.capabilities import Capability, CapabilityRegistry
 from testsuite.openshift.client import OpenShiftClient
 from testsuite.openshift.crd.apicast import APIcast
 from testsuite.openshift.env import Environ
@@ -19,6 +19,10 @@ class OperatorApicast(SelfManagedApicast):
         super().__init__(staging, openshift, name, generate_name)
         self.portal_endpoint = portal_endpoint
         self.apicast = None
+
+    @staticmethod
+    def fits():
+        return Capability.OCP4 in CapabilityRegistry()
 
     @property
     def deployment(self):

--- a/testsuite/gateways/apicast/template.py
+++ b/testsuite/gateways/apicast/template.py
@@ -7,6 +7,7 @@ import importlib_resources as resources
 from testsuite.openshift.objects import SecretTypes
 from testsuite.openshift.client import OpenShiftClient
 from .selfmanaged import SelfManagedApicast
+from ...capabilities import CapabilityRegistry, Capability
 
 LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +35,10 @@ class TemplateApicast(SelfManagedApicast):
                 "CONFIGURATION_LOADER": "lazy",
                 "DEPLOYMENT_ENVIRONMENT": "staging",
                 "CONFIGURATION_CACHE": 0})
+
+    @staticmethod
+    def fits():
+        return Capability.OCP3 in CapabilityRegistry()
 
     def _create_configuration_url_secret(self):
         self.openshift.secrets.create(


### PR DESCRIPTION
* Based heavily on @mganisin proposal
* Instantiating `SelfManagedApicast` will return valid subclass that fits the current environment.
    * For OCP3 it will create `TemplateApicast`  and for OCP4 `OperatorApicast`
* For the time being, it removes the ability to use `IndependentApicast` as it will reimplemented in the future PR.
* For the time being. not tests actually use this gateway!
   * More work needs to be done to make `TemplateApicast` and `OperatorApicast` interchangable   
