### PR TITLE
Remove unnecessary *_client fixtures

### DIFF
--- a/testsuite/tests/prometheus/apicast/test_content_caching_policy.py
+++ b/testsuite/tests/prometheus/apicast/test_content_caching_policy.py
@@ -36,22 +36,6 @@ def service(service):
     return service
 
 
-@pytest.fixture(scope="module")
-def prod_client(prod_client):
-    """Hit production apicast so that we can have metrics from it and that we can cache incoming requests"""
-    client = prod_client()
-    assert client.get("/anything").status_code == 200
-    return client
-
-
-@pytest.fixture(scope="module")
-def api_client(api_client):
-    """Apicast needs to load configuration in order to cache incoming requests"""
-    client = api_client()
-    assert client.get("/anything").status_code == 200
-    return client
-
-
 @pytest.mark.disruptive
 @pytest.mark.parametrize(("client", "apicast"), [("api_client", "apicast-staging"),
                                                  ("prod_client", "apicast-production")
@@ -62,6 +46,7 @@ def test_content_caching(request, prometheus, client, apicast):
     Test if cache works correctly and if prometheus contains content_caching metric.
     """
     client = request.getfixturevalue(client)
+    client = client()
     counts_before = extract_caching(prometheus, "content_caching", apicast)
 
     response = client.get("/anything/test", headers=dict(origin="localhost"))

--- a/testsuite/tests/prometheus/apicast/test_metrics.py
+++ b/testsuite/tests/prometheus/apicast/test_metrics.py
@@ -26,20 +26,6 @@ METRICS = [
 STATUSES = [300, 418, 507]
 
 
-@pytest.fixture(scope="module")
-def api_client(api_client):
-    """Returns stage client instance."""
-    client = api_client()
-    return client
-
-
-@pytest.fixture(scope="module")
-def prod_client(prod_client):
-    """Returns prod client instance."""
-    client = prod_client()
-    return client
-
-
 # pylint: disable=unused-argument
 @pytest.fixture(scope="module", params=["apicast-staging", "apicast-production"])
 def metrics(request, prometheus):
@@ -85,6 +71,7 @@ def test_apicast_status_metrics(request, client, container, prometheus):
     """
 
     client = request.getfixturevalue(client)
+    client = client()
 
     for status in STATUSES:
         assert client.get(f"/status/{status}").status_code == status


### PR DESCRIPTION
conftest contains fixture to check presence of metrics, and in case of missing
key, it will do necessary api call to generate required metric.