### PR TITLE
Handle SIGTERM with SIGINT handler for a duration of tests

### DIFF
--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -3,6 +3,7 @@
 import inspect
 import logging
 import os
+import signal
 import time
 
 import importlib_resources as resources
@@ -27,6 +28,17 @@ from testsuite.utils import blame, blame_desc, warn_and_skip
 from testsuite.rhsso import RHSSOServiceConfiguration, RHSSO
 
 pytest_plugins = ("testsuite.gateway_logs",)
+
+
+@pytest.fixture(scope='session', autouse=True)
+def term_handler():
+    """
+    This will handle ^C, cleanup won't be skipped
+    https://github.com/pytest-dev/pytest/issues/9142
+    """
+    orig = signal.signal(signal.SIGTERM, signal.getsignal(signal.SIGINT))
+    yield
+    signal.signal(signal.SIGTERM, orig)
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
In case of Abort in Jenkins or `^C` when running tests from shell, pytest would be killed and cleanup would not run.
This will ensure that Abort in Jenkins or ^C would not kill pytest, only test execution would be stopped, cleanups would be executed as expected.

solution taken from https://github.com/pytest-dev/pytest/issues/9142