### PR TITLE
Custom tenat test 

### DIFF
--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -795,16 +795,7 @@ def custom_tenant(testconfig, master_threescale, request):
         master_threescale.accounts.read_by_name(user_name).users.read_by_name(user_name).activate()
 
         if wait:
-            admin_base_url = tenant.entity["signup"]["account"]["admin_base_url"]
-            access_token = tenant.entity["signup"]["access_token"]["value"]
-
-            unprivileged_client = client.ThreeScaleClient(admin_base_url, access_token, ssl_verify=False)
-
-            @backoff.on_exception(backoff.fibo, errors.ApiClientError, max_tries=8, jitter=None)
-            def _wait_on_ready_tenant():
-                unprivileged_client.services.list()
-
-            _wait_on_ready_tenant()
+            tenant.wait_tenant_ready()
 
         return tenant
 

--- a/testsuite/tests/custom_tenant/test_custom_tenant.py
+++ b/testsuite/tests/custom_tenant/test_custom_tenant.py
@@ -2,41 +2,23 @@
 rewritten the /spec/functional_specs/custom_tenant_spec.rb
 Creates a new tenant and tests if the tenant works
 """
-import backoff
 import pytest
-from threescale_api import client
 
 
 @pytest.fixture(scope="session")
-def threescale(custom_tenant, testconfig):
+def threescale(custom_tenant):
     """
     Creates a new tenant and returns a threescale client configured to use
     the new tenant
     """
-    tenant = custom_tenant()
-
-    url = "https://" + tenant.entity["signup"]["account"]["admin_domain"]
-    access_token = tenant.entity["signup"]["access_token"]["value"]
-
-    verify = testconfig["ssl_verify"]
-    return get_custom_client(url, access_token, verify)
-
-
-@backoff.on_predicate(backoff.fibo,
-                      lambda x: not x.account_plans.exists() or len(x.account_plans.fetch()["plans"]) < 1,
-                      8, jitter=None)
-def get_custom_client(url, access_token, ssl_verify):
-    """
-    Given the credentials, returns a client for the custom tenant.
-    Retries until an account plan is created. When that object exists, tenant is ready.
-    When fetching account plans without previous check if they have been created
-    503 error can be returned
-    """
-    return client.ThreeScaleClient(url=url, token=access_token, ssl_verify=ssl_verify)
+    return custom_tenant().admin_api(wait=True)
 
 
 # FIXME: threescale_api.errors.ApiClientError: Response(422): b'{"errors":{"system_name":["must be shorter."]}}
 # Name of the tenant is too long
+# ^ no longer occurring
+# FIXME: threescale_api.errors.ApiClientError: Response(404 Not Found): b'{"status":"Not found"}'
+# ^ causing backoff on _custom_account
 @pytest.mark.flaky
 def test_custom_tenant(api_client):
     """

--- a/testsuite/tests/toolbox/conftest.py
+++ b/testsuite/tests/toolbox/conftest.py
@@ -18,10 +18,7 @@ def dest_client(request) -> client.ThreeScaleClient:
     else:
         tenant = request.getfixturevalue("custom_tenant")()
 
-        destination_endpoint = tenant.entity["signup"]["account"]["admin_base_url"]
-        destination_provider = tenant.entity["signup"]["access_token"]["value"]
-
-        unprivileged_client = client.ThreeScaleClient(destination_endpoint, destination_provider, ssl_verify=False)
+        unprivileged_client = tenant.admin_api(wait=True)
 
         token_name = blame(request, "at")
 
@@ -29,6 +26,7 @@ def dest_client(request) -> client.ThreeScaleClient:
             token_name, "rw", ["finance", "account_management",
                                "stats", "policy_registry"]))
 
+        destination_endpoint = tenant.admin_base_url
         destination_provider = access_token["value"]  # overriding with greater and better access key
 
     return client.ThreeScaleClient(destination_endpoint,


### PR DESCRIPTION
There is backoff in a test so we don't need to wait in fixture.
Updating the reason for mark.flaky.