### PR TITLE
Implement environmental varables in OperatorApicast through CRD

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -39,7 +39,7 @@ widgetastic-patternfly = "*"
 # 3scale-api = {editable = true,path = "./../3scale-api-python"}
 # 3scale-api = {git = "https://github.com/pestanko/3scale-api-python.git", editable = true}
 cfssl = "==0.0.3b243"
-openshift-client = ">=1.0.9"
+openshift-client = ">=1.0.14"
 hyperfoil-client="*"
 paramiko = "*"
 docker = "*"

--- a/testsuite/gateways/apicast/containers.py
+++ b/testsuite/gateways/apicast/containers.py
@@ -5,7 +5,7 @@ from threescale_api.resources import Service
 
 from testsuite.capabilities import Capability
 from testsuite.gateways.apicast import AbstractApicast
-from testsuite.openshift.env import Environ
+from testsuite.openshift.env import Properties
 
 
 class ContainerizedApicast(AbstractApicast):
@@ -41,5 +41,5 @@ class ContainerizedApicast(AbstractApicast):
         raise NotImplementedError()
 
     @property
-    def environ(self) -> Environ:
+    def environ(self) -> Properties:
         raise NotImplementedError("ContainerizedAPIcast doesn't support environ yet")

--- a/testsuite/gateways/apicast/operator.py
+++ b/testsuite/gateways/apicast/operator.py
@@ -1,5 +1,6 @@
 """Apicast deployed with ApicastOperator"""
 import time
+from typing import Dict
 
 from testsuite.capabilities import Capability, CapabilityRegistry
 from testsuite.openshift.client import OpenShiftClient
@@ -9,9 +10,85 @@ from testsuite.openshift.env import Properties
 from .selfmanaged import SelfManagedApicast
 
 
+def apicast_service_list(apicast: APIcast, services: str):
+    """Sets APICAST_SERVICE_LIST in the APIcast CR """
+    service_list = str(services).split(",")
+    apicast["enabledServices"] = service_list
+
+
+class OperatorEnviron(Properties):
+    """
+    Implements Properties for use in Operator and
+    transforms APIcast environmental variables into operator properties
+    """
+    def __init__(self, apicast: APIcast, wait_function) -> None:
+        self.apicast = apicast
+        self.wait_function = wait_function
+
+    NAMES = {
+        "APICAST_SERVICES_FILTER_BY_URL": "servicesFilterByURL",
+        "APICAST_SERVICES_LIST": apicast_service_list,
+        "APICAST_UPSTREAM_RETRY_CASES": "upstreamRetryCases",
+        "APICAST_HTTPS_VERIFY_DEPTH": "httpsVerifyDepth",
+        # "APICAST_ACCESS_LOG_FILE": "" Doesnt exists yet!,
+        # "THREESCALE_CONFIG_FILE": "" Doesnt exists yet!
+        "APICAST_PATH_ROUTING": "pathRoutingEnabled",
+        # "APICAST_PATH_ROUTING_ONLY": "" Doesnt exists yet!
+        "HTTP_PROXY": "httpProxy",
+        "HTTPS_PROXY": "httpsProxy",
+        "NO_PROXY": "noProxy",
+        "ALL_PROXY": "allProxy",
+        "APICAST_LOAD_SERVICES_WHEN_NEEDED": "loadServicesWhenNeeded",
+        "APICAST_CACHE_STATUS_CODES": "cacheStatusCodes",
+        "APICAST_CACHE_MAX_TIME": "cacheMaxTime",
+        # "APICAST_SERVICE_{service.entity_id}_CONFIGURATION_VERSION": ""  # TODO: Works differently
+    }
+
+    def _set(self, name, value, commit=True):
+        if name in self.NAMES:
+            key = self.NAMES[name]
+            if callable(key):
+                key(self.apicast, value)
+            else:
+                self.apicast[key] = value
+            if commit:
+                self.apicast.apply()
+                self.wait_function()
+        else:
+            raise NotImplementedError(f"Env variable {name} doesn't exists or is not yet implemented in operator")
+
+    def set_many(self, envs: Dict[str, str]):
+        for name, value in envs.items():
+            self._set(name, value, commit=False)
+        self.apicast.apply()
+        self.wait_function()
+
+    def __getitem__(self, name):
+        if name in self.NAMES:
+            key = self.NAMES[name]
+            if callable(key):
+                raise NotImplementedError(f"Callable env variable {name} cannot be read yet")
+            return self.apicast[key]
+        raise NotImplementedError(f"Env variable {name} doesn't exists or is not yet implemented in operator")
+
+    def __setitem__(self, name, value):
+        self._set(name, value)
+
+    def __delitem__(self, name):
+        if name in self.NAMES:
+            key = self.NAMES[name]
+            if callable(key):
+                raise NotImplementedError(f"Callable env variable {name} cannot be deleted yet")
+            del self.apicast[key]
+            self.apicast.apply()
+            self.wait_function()
+        else:
+            raise NotImplementedError(f"Env variable {name} doesn't exists or is not yet implemented in operator")
+
+
 class OperatorApicast(SelfManagedApicast):
     """Gateway for use with APIcast deployed by operator"""
-    CAPABILITIES = {Capability.APICAST, Capability.PRODUCTION_GATEWAY}
+    CAPABILITIES = {Capability.APICAST, Capability.PRODUCTION_GATEWAY, Capability.CUSTOM_ENVIRONMENT}
 
     # pylint: disable=too-many-arguments
     def __init__(self, staging: bool, openshift: OpenShiftClient, name, portal_endpoint, generate_name=False) -> None:
@@ -31,7 +108,9 @@ class OperatorApicast(SelfManagedApicast):
 
     @property
     def environ(self) -> Properties:
-        raise NotImplementedError("Operator doesn't support environment")
+        if self._environ is None:
+            self._environ = OperatorEnviron(self.apicast, self.reload)
+        return self._environ
 
     def reload(self):
         self.openshift.do_action("delete", ["pod", "--force",

--- a/testsuite/gateways/apicast/operator.py
+++ b/testsuite/gateways/apicast/operator.py
@@ -4,7 +4,7 @@ import time
 from testsuite.capabilities import Capability, CapabilityRegistry
 from testsuite.openshift.client import OpenShiftClient
 from testsuite.openshift.crd.apicast import APIcast
-from testsuite.openshift.env import Environ
+from testsuite.openshift.env import Properties
 
 from .selfmanaged import SelfManagedApicast
 
@@ -19,6 +19,7 @@ class OperatorApicast(SelfManagedApicast):
         super().__init__(staging, openshift, name, generate_name)
         self.portal_endpoint = portal_endpoint
         self.apicast = None
+        self._environ: OperatorEnviron = None  # type: ignore
 
     @staticmethod
     def fits():
@@ -29,7 +30,7 @@ class OperatorApicast(SelfManagedApicast):
         return f"apicast-{super().deployment}"
 
     @property
-    def environ(self) -> Environ:
+    def environ(self) -> Properties:
         raise NotImplementedError("Operator doesn't support environment")
 
     def reload(self):

--- a/testsuite/gateways/apicast/selfmanaged.py
+++ b/testsuite/gateways/apicast/selfmanaged.py
@@ -8,7 +8,7 @@ from testsuite import utils
 from testsuite.capabilities import Capability
 from testsuite.gateways.apicast import AbstractApicast
 from testsuite.openshift.client import OpenShiftClient
-from testsuite.openshift.env import Environ
+from testsuite.openshift.env import Properties
 from testsuite.openshift.objects import Routes
 
 LOGGER = logging.getLogger(__name__)
@@ -139,7 +139,7 @@ class SelfManagedApicast(AbstractApicast):
             self._routes.remove(name)
 
     @property
-    def environ(self) -> Environ:
+    def environ(self) -> Properties:
         return self.openshift.environ(self.deployment)
 
     def reload(self):

--- a/testsuite/gateways/apicast/system.py
+++ b/testsuite/gateways/apicast/system.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 from testsuite.capabilities import Capability
 from testsuite.gateways.apicast import AbstractApicast
-from testsuite.openshift.env import Environ
+from testsuite.openshift.env import Properties
 
 if TYPE_CHECKING:
     # pylint: disable=cyclic-import
@@ -28,7 +28,7 @@ class SystemApicast(AbstractApicast):
         self.openshift: "OpenShiftClient" = openshift
 
     @property
-    def environ(self) -> Environ:
+    def environ(self) -> Properties:
         return self.openshift.environ(self.deployment)
 
     def reload(self):

--- a/testsuite/gateways/gateways.py
+++ b/testsuite/gateways/gateways.py
@@ -4,7 +4,7 @@ from typing import Set
 
 from testsuite.capabilities import Capability
 from testsuite.lifecycle_hook import LifecycleHook
-from testsuite.openshift.env import Environ
+from testsuite.openshift.env import Properties
 
 
 class AbstractGateway(LifecycleHook, ABC):
@@ -14,7 +14,7 @@ class AbstractGateway(LifecycleHook, ABC):
     HAS_PRODUCTION = False
 
     @property
-    def environ(self) -> Environ:
+    def environ(self) -> Properties:
         """Returns environ object for given gateway"""
         raise NotImplementedError()
 

--- a/testsuite/gateways/service_mesh/mesh.py
+++ b/testsuite/gateways/service_mesh/mesh.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse, urlunparse
 from openshift import Selector
 
 from testsuite.openshift.client import OpenShiftClient
-from testsuite.openshift.env import Environ
+from testsuite.openshift.env import Properties
 
 
 class ServiceMesh:
@@ -77,6 +77,6 @@ class ServiceMesh:
         return self._ingress_url
 
     @property
-    def environ(self) -> Environ:
+    def environ(self) -> Properties:
         """Returns Environ object for manipulation of the adapter environment"""
         return self.openshift.deployment_environ("3scale-istio-adapter")

--- a/testsuite/openshift/crd/apicast.py
+++ b/testsuite/openshift/crd/apicast.py
@@ -62,3 +62,6 @@ class APIcast(APIObject):
 
     def __setitem__(self, key, value):
         self.model.spec[key] = value
+
+    def __delitem__(self, key):
+        del self.model.spec[key]

--- a/testsuite/openshift/env.py
+++ b/testsuite/openshift/env.py
@@ -1,4 +1,5 @@
 """Module containing classes that manipulate deployment configs environment"""
+import abc
 import re
 import logging
 from typing import TYPE_CHECKING, Callable, Match, Dict
@@ -77,6 +78,27 @@ class ConfigMapEnvironmentVariable(EnvironmentVariable):
 
 
 logger = logging.getLogger(__name__)
+
+
+class Properties(abc.ABC):
+    """Abstract class for manipulating objects properties, albeit operator properties or deployments environmental
+    variables"""
+
+    @abc.abstractmethod
+    def set_many(self, envs: Dict[str, str]):
+        """Allow setting many envs at a time."""
+
+    @abc.abstractmethod
+    def __getitem__(self, name):
+        """Returns item"""
+
+    @abc.abstractmethod
+    def __setitem__(self, name, value):
+        """Sets item"""
+
+    @abc.abstractmethod
+    def __delitem__(self, name):
+        """Deletes item"""
 
 
 class Environ:

--- a/testsuite/tests/apicast/parameters/conftest.py
+++ b/testsuite/tests/apicast/parameters/conftest.py
@@ -15,9 +15,9 @@ def require_openshift(testconfig):
 
 
 @pytest.fixture(scope="module")
-def staging_gateway(request, gateway_environment, gateway_options):
+def staging_gateway(request, gateway_kind, gateway_environment, gateway_options):
     """Deploy self-managed template based apicast gateway."""
-    gw = gateway(kind=TemplateApicast, staging=True, name=blame(request, "gw"), **gateway_options)
+    gw = gateway(kind=gateway_kind, staging=True, name=blame(request, "gw"), **gateway_options)
     request.addfinalizer(gw.destroy)
     gw.create()
 
@@ -25,6 +25,12 @@ def staging_gateway(request, gateway_environment, gateway_options):
         gw.environ.set_many(gateway_environment)
 
     return gw
+
+
+@pytest.fixture(scope="module")
+def gateway_kind():
+    """Gateway class to use for tests"""
+    return TemplateApicast
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/filter_by_url/test_oidc_timeout_err_filter_by_url.py
+++ b/testsuite/tests/apicast/parameters/filter_by_url/test_oidc_timeout_err_filter_by_url.py
@@ -17,6 +17,7 @@ from threescale_api.resources import Service
 
 from testsuite.capabilities import Capability
 from testsuite.gateways import gateway
+from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 from testsuite.gateways.apicast.template import TemplateApicast
 from testsuite.utils import blame
 from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
@@ -25,6 +26,12 @@ pytestmark = [
     pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY),
     pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6139")]
+
+
+@pytest.fixture(scope="module")
+def gateway_kind():
+    """Gateway class to use for tests"""
+    return SelfManagedApicast
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/testsuite/tests/apicast/parameters/http_proxy/large_data/conftest.py
+++ b/testsuite/tests/apicast/parameters/http_proxy/large_data/conftest.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 import pytest
 
 from testsuite import rawobj
+from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 from testsuite.utils import blame
 
 
@@ -14,6 +15,12 @@ from testsuite.utils import blame
 def protocol(request):
     """Protocol which is used on http(s) service/proxy/backend"""
     return request.param
+
+
+@pytest.fixture(scope="module")
+def gateway_kind():
+    """Gateway class to use for tests"""
+    return SelfManagedApicast
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/http_proxy/test_http_proxy.py
+++ b/testsuite/tests/apicast/parameters/http_proxy/test_http_proxy.py
@@ -7,8 +7,15 @@ import pytest
 
 from testsuite import rawobj
 from testsuite.capabilities import Capability
+from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 
 pytestmark = [pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY)]
+
+
+@pytest.fixture(scope="module")
+def gateway_kind():
+    """Gateway class to use for tests"""
+    return SelfManagedApicast
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/policies/test_content_caching_policy_parameters.py
+++ b/testsuite/tests/apicast/parameters/policies/test_content_caching_policy_parameters.py
@@ -11,10 +11,17 @@ import pytest
 from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.echoed_request import EchoedRequest
 from testsuite.capabilities import Capability
+from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 from testsuite.utils import blame, randomize
 
 pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
               pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY)]
+
+
+@pytest.fixture(scope="module")
+def gateway_kind():
+    """Gateway class to use for tests"""
+    return SelfManagedApicast
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/test_apicast_service.py
+++ b/testsuite/tests/apicast/parameters/test_apicast_service.py
@@ -5,11 +5,18 @@ import pytest
 
 from testsuite import rawobj
 from testsuite.capabilities import Capability
+from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 from testsuite.utils import blame
 
 pytestmark = [
     pytest.mark.required_capabilities(Capability.APICAST, Capability.CUSTOM_ENVIRONMENT),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-1524")]
+
+
+@pytest.fixture(scope="module")
+def gateway_kind():
+    """Gateway class to use for tests"""
+    return SelfManagedApicast
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/test_apicast_services_list.py
+++ b/testsuite/tests/apicast/parameters/test_apicast_services_list.py
@@ -6,9 +6,16 @@ import pytest
 
 from testsuite import rawobj
 from testsuite.capabilities import Capability
+from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 from testsuite.utils import blame
 
 pytestmark = pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY)
+
+
+@pytest.fixture(scope="module")
+def gateway_kind():
+    """Gateway class to use for tests"""
+    return SelfManagedApicast
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
* It is possible to set/get environmental variables in `OperatorApicast` through `environ()` method.
   * CRD is used instead of directly changing the deployment
   * delete is not yet supported, since it is not used at all
*  Not all environmental variables are implemented yet
   * This will be done in subsequent PRs
* Extracted `Properties` interface from `Environ` and made `environ()` method return `Properties`
* Add `OperatorEnviron` which handles transforming from env vars to CRD names
* Changed tests to use `SelfManagedApicast` instead of `TemplateApicast` where possible.
   * This means the tests will use `OperatorApicast` on OCP4 and `TemplateApicast` on ocp3  
   * Choose opt-in approached as it will be clearly visible from PRs which tests are now supported on OCP4
 
 If the number of files this PR changes is too much, it is possible to split this in two, where one is the first commit only.