### PR TITLE
Fix: Prometheus metrics for apicast will be checked for both envs (stage, prod)

### DIFF
--- a/testsuite/tests/prometheus/apicast/conftest.py
+++ b/testsuite/tests/prometheus/apicast/conftest.py
@@ -10,8 +10,14 @@ def check_availability(api_client, prod_client, prometheus):
     Checks whether is the prometheus configured to run tests in this module.
     """
 
-    if not prometheus.has_metric(
-            "apicast_status",
-            lambda: (api_client().get('/anything'), prod_client().get('/anything'))):
+    if not prometheus.has_metrics(
+            "apicast_status", "apicast-staging",
+            lambda: api_client().get('/anything')):
+        warn_and_skip("The Prometheus is not configured to run this test. The collection"
+                      " of basic metrics is not set up. The test has been skipped.")
+
+    if not prometheus.has_metrics(
+            "apicast_status", "apicast-production",
+            lambda: prod_client().get('/anything')):
         warn_and_skip("The Prometheus is not configured to run this test. The collection"
                       " of basic metrics is not set up. The test has been skipped.")

--- a/testsuite/tests/prometheus/apicast/test_content_caching_policy.py
+++ b/testsuite/tests/prometheus/apicast/test_content_caching_policy.py
@@ -61,7 +61,6 @@ def test_content_caching(request, prometheus, client, apicast):
     time.sleep(PROMETHEUS_REFRESH)
 
     metrics = prometheus.get_metrics(apicast)
-    metrics = [m["metric"] for m in metrics["data"]]
     assert "content_caching" in metrics
 
     counts_after = extract_caching(prometheus, "content_caching", apicast)

--- a/testsuite/tests/prometheus/apicast/test_metrics.py
+++ b/testsuite/tests/prometheus/apicast/test_metrics.py
@@ -31,12 +31,9 @@ STATUSES = [300, 418, 507]
 def metrics(request, prometheus):
     """Return all metrics from target defined of staging and also production apicast."""
     metrics = prometheus.get_metrics(request.param)
-    return {m["metric"] for m in metrics["data"]}
+    return metrics
 
 
-# flaky as the testsuite does not trigger the metrics that are expected, their presence
-# depends on prior usage of the gateway
-@pytest.mark.flaky
 @pytest.mark.parametrize("expected_metric", METRICS)
 def test_metrics_from_target_must_contains_apicast_metrics(expected_metric, metrics):
     """Metrics must contains expected apicast metrics defined in METRICS."""

--- a/testsuite/tests/prometheus/system/test_metrics.py
+++ b/testsuite/tests/prometheus/system/test_metrics.py
@@ -45,7 +45,7 @@ pytestmark = [
 def metrics_master(prometheus):
     """Return all metrics from target defined of system-master."""
     metrics = prometheus.get_metrics("system-master")
-    return {m["metric"] for m in metrics["data"]}
+    return metrics
 
 
 # pylint: disable=unused-argument
@@ -53,7 +53,7 @@ def metrics_master(prometheus):
 def metrics_sidekiq(prometheus):
     """Return all metrics from target defined of system-master."""
     metrics = prometheus.get_metrics("system-sidekiq")
-    return {m["metric"] for m in metrics["data"]}
+    return metrics
 
 
 @pytest.mark.parametrize("metric", METRICS_MASTER)


### PR DESCRIPTION
`testsuite/tests/prometheus/apicast/conftest.py` will check for `apicast_status` with labels `container="apicast-staging"` and `container="apicast-production"`, each has it's own trigger call.

All usages of `get_metrics` will get metrics name, so it can be done in the function directly.