### PR TITLE
fixed app description to prevent yaml parse error

### DIFF
--- a/testsuite/tests/system/messages/mail_templates.yml
+++ b/testsuite/tests/system/messages/mail_templates.yml
@@ -20,7 +20,7 @@ subject_templates:
       this because you subscribed to this notification.<br />View notification preferences
       on <a href=3D"https://3scale-admin.<threescale_superdomain>/p/admin/user/notification_preferences">3scale.net</a>
       </p></body></html>----==_mimepart_(?!-).*--'
-  <application> signup created on <service>:
+  <application> created on <service>:
       Headers: '{"unique_args":{"event_name":"Applications::ApplicationCreatedEvent","event_id":".*","user_id":[0-9]+,"account_id":[0-9]+},"category":\["notification","applications/application_created_event"\]}'
       Body: '----==_mimepart_.+Content-Type: text/plain; charset=UTF-8Content-Transfer-Encoding:
       7bitDear <username>,A new application subscribed to the <aplan> plan on the

--- a/testsuite/tests/system/messages/test_email_accounts.py
+++ b/testsuite/tests/system/messages/test_email_accounts.py
@@ -11,13 +11,19 @@ import pytest
 import yaml
 import backoff
 
+from testsuite import rawobj
+from testsuite.utils import blame
+
 
 @pytest.fixture
-def application(application):
-    """Change the application description to avoid errors in YAML parsing
-    """
-    application.update({'description': 'API signup'})
-    return application
+def application(service, custom_application, custom_app_plan, lifecycle_hooks, request):
+    "application bound to the account and service with specific description that don't break yaml parsing"
+    plan = custom_app_plan(rawobj.ApplicationPlan(blame(request, "aplan")), service)
+    app = custom_application(
+        rawobj.Application(blame(request, "app"), plan, "Api signup"), hooks=lifecycle_hooks,
+        annotate=False)
+    service.proxy.deploy()
+    return app
 
 
 @pytest.fixture


### PR DESCRIPTION
The app name and app description were breaking the test under some conditions, this PR should fix it.