### PR TITLE
Extend socket timeout

### DIFF
--- a/testsuite/__init__.py
+++ b/testsuite/__init__.py
@@ -30,7 +30,7 @@ from testsuite.configuration import CommonConfiguration  # noqa
 # To avoid indefinite waiting on socket issues default timeout is used.
 # Furthermore to avoid reset of timeout, monkey patching is used to alter
 # socket.settimeout behavior
-socket.setdefaulttimeout(60)
+socket.setdefaulttimeout(120)
 _socket_settimeout = socket.socket.settimeout
 
 


### PR DESCRIPTION
I believe current timeout is absolutely sufficient to reveal that
something is wrong in communication, anyway the timeout can be seen
relatively often, therefore slight extend is worth trying to see whether
it will make the behavior better.