### PR TITLE
Reorganize asserts in headers JWT test

### DIFF
--- a/testsuite/tests/apicast/policy/headers/test_headers_policy_jwt.py
+++ b/testsuite/tests/apicast/policy/headers/test_headers_policy_jwt.py
@@ -61,7 +61,7 @@ def test_headers_policy_extra_headers(api_client, rhsso_service_info, applicatio
     # add 10 seconds to now because there can be different times
     # in Jenkins machine and machine with Apicast
     now = time.time() + 10
-    assert float(exp) > now
-    assert float(iat) <= now
     assert rhsso_service_info.issuer_url() == iss
     assert azp == application["application_id"]
+    assert float(exp) > now
+    assert float(iat) <= now


### PR DESCRIPTION
If it fails at incorrect times it will at least pass the other asserts which I believe are much better at telling us if it is working or not.