### PR TITLE
Restore extra get request in test_content_caching

### DIFF
--- a/testsuite/tests/prometheus/apicast/test_content_caching_policy.py
+++ b/testsuite/tests/prometheus/apicast/test_content_caching_policy.py
@@ -45,8 +45,10 @@ def test_content_caching(request, prometheus, client, apicast):
     """
     Test if cache works correctly and if prometheus contains content_caching metric.
     """
-    client = request.getfixturevalue(client)
-    client = client()
+    client = request.getfixturevalue(client)()
+    # """Hit apicast so that we can have metrics from it and that we can cache incoming requests"""
+    # """Apicast needs to load configuration in order to cache incoming requests"""
+    client.get("/get")
     counts_before = extract_caching(prometheus, "content_caching", apicast)
 
     response = client.get("/anything/test", headers=dict(origin="localhost"))


### PR DESCRIPTION
Removed client fixtures included extra get claiming some initialization,
it is returned in test body