### PR TITLE
Add default apicast-operator project

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -12,6 +12,10 @@ default:
     gateway:
       TemplateApicast:
         template: apicast.yml
+      OperatorApicast:
+        openshift:
+          project_name: "apicast-operator"
+          kind: "OpenShiftClient"
       default:
         kind: "SystemApicast"
   rhsso:


### PR DESCRIPTION
* Operator APIcast will use by default `apicast-operator` project on the same cluster.