### PR TITLE
Introduce fast testing make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ test: ## Run test
 test pytest tests: pipenv
 	$(PYTEST) -n4 -m 'not flaky' $(flags) testsuite
 
+speedrun: ## Bigger than smoke faster than test
+speedrun: pipenv
+	$(PYTEST) -n4 -m 'not flaky' --drop-sandbag $(flags) testsuite
+
 debug: ## Run test  with debug flags
 debug: flags := $(flags) -s
 debug: test

--- a/README.md
+++ b/README.md
@@ -138,6 +138,9 @@ Alternatively it can be set in the configuration.
 `make test NAMESPACE=3scale`
  - general way to run the testsuite; troublesome tests excluded == no flaky or disruptive
 
+`make speedrun NAMESPACE=3scale`
+ - this is 'test' just even more reduced to provide better coverage than smoke but still fast enough
+
 `make flaky NAMESPACE=3scale`
  - unstable tests causing false alarms
 
@@ -155,11 +158,22 @@ Targets can be combined
 `make ./testsuite/tests/apicast/auth/test_basic_auth_user_key.py NAMESPACE=3scale`
  - to run particular test standalone
 
+### Test Selection, Marks and Custom Arguments
+
+Selection of tests in the targets described above is based on pytest marks and
+extra commandline options. Marks should be used wisely and reviewed carefully
+and extra care is required when combining marks on one test. For example
+`pytest.mark.disruptive` on some UI test causes that neither `make ui` nor
+`make disruptive` without extra option runs such test. This danger applies to
+selections based on the arguments, e.g. `pytest.mark.flaky` is safe to combine
+with anything, it just doesn't have to be reasonable for every case.
+
 ### pytest Arguments
 
 The arguments to pytest can be passed as `flags=` variable:
 
 `make smoke NAMESPACE=3scale flags=--junitxml=junit.xml`
+
 
 ## Run the tests in container
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 markers =
 	disruptive: This has side effect with possible impact on other tests
 	performance: Performance tests have unique needs
-	slow: This is time consuming
+	sandbag: Either slow, deployment sensitive or requires complex setup
 	smoke: Build verification test
 	flaky: Random failures with unclear reason
 	required_capabilities(capability1, capability2, ...): List of capabilities that are required for running this test

--- a/testsuite/tests/apicast/policy/batcher/test_batcher_policy_oidc.py
+++ b/testsuite/tests/apicast/policy/batcher/test_batcher_policy_oidc.py
@@ -24,7 +24,7 @@ def policy_settings():
     return rawobj.PolicyConfig("3scale_batcher", {"batch_report_seconds": BATCH_REPORT_SECONDS})
 
 
-@pytest.mark.slow
+@pytest.mark.sandbag  # slow due to long sleep
 def test_batcher_policy_oidc(api_client, application, rhsso_service_info):
     """Test if return correct number of usages of a service in batch"""
     app_key = application.keys.list()["keys"][0]["key"]["value"]

--- a/testsuite/tests/apicast/policy/test_incorrect_name_policy.py
+++ b/testsuite/tests/apicast/policy/test_incorrect_name_policy.py
@@ -21,7 +21,6 @@ def test_incorrect_name_policy_staging_call(api_client):
     assert response.status_code == 200
 
 
-@pytest.mark.slow
 @pytest.mark.disruptive
 @pytest.mark.required_capabilities(Capability.PRODUCTION_GATEWAY)
 def test_incorrect_name_policy_production_call(prod_client):

--- a/testsuite/tests/apicast/policy/websocket/test_websocket_policy_app_id.py
+++ b/testsuite/tests/apicast/policy/websocket/test_websocket_policy_app_id.py
@@ -7,7 +7,10 @@ from threescale_api.resources import Service
 from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.tests.apicast.policy.websocket.conftest import retry_sucessful, retry_failing
 
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.8')")]
+# websockets may fail on some deployments probably because of TLS config mismatch
+pytestmark = [
+        pytest.mark.sandbag,
+        pytest.mark.skipif("TESTED_VERSION < Version('2.8')")]
 
 
 @pytest.fixture

--- a/testsuite/tests/apicast/policy/websocket/test_websocket_policy_user_key.py
+++ b/testsuite/tests/apicast/policy/websocket/test_websocket_policy_user_key.py
@@ -6,7 +6,10 @@ import pytest
 from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.tests.apicast.policy.websocket.conftest import retry_sucessful, retry_failing
 
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.8')")]
+# websockets may fail on some deployments probably because of TLS config mismatch
+pytestmark = [
+        pytest.mark.sandbag,
+        pytest.mark.skipif("TESTED_VERSION < Version('2.8')")]
 
 
 @pytest.fixture

--- a/testsuite/tests/apicast/policy/websocket/test_websocket_policy_wss_backend.py
+++ b/testsuite/tests/apicast/policy/websocket/test_websocket_policy_wss_backend.py
@@ -6,7 +6,10 @@ import pytest
 from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
 from testsuite.tests.apicast.policy.websocket.conftest import retry_sucessful, retry_failing
 
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.8')")]
+# websockets may fail on some deployments probably because of TLS config mismatch
+pytestmark = [
+        pytest.mark.sandbag,
+        pytest.mark.skipif("TESTED_VERSION < Version('2.8')")]
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/system/messages/test_account_message.py
+++ b/testsuite/tests/system/messages/test_account_message.py
@@ -4,6 +4,7 @@ When sending message to a developer account, the email is send
 """
 
 import backoff
+import pytest
 
 
 @backoff.on_exception(backoff.fibo, AssertionError, 8, jitter=None)
@@ -15,6 +16,8 @@ def assert_message_received(mailhog, text):
     return ids
 
 
+# requires mailhog *AND* special deployment with preconfigured smtp secret
+@pytest.mark.sandbag
 def test_account_will_receive_email(mailhog_client, threescale, account):
     """
     Sends a message to an account

--- a/testsuite/tests/system/messages/test_email_accounts.py
+++ b/testsuite/tests/system/messages/test_email_accounts.py
@@ -96,8 +96,10 @@ def clean_up(mailhog_client, mail_template):
     mailhog_client.delete(ids)
 
 
+# requires mailhog *AND* special deployment with preconfigured smtp secret
 # pylint: disable=unused-argument
 @backoff.on_exception(backoff.fibo, AssertionError, 8, jitter=None)
+@pytest.mark.sandbag
 def test_emails_after_account_creation(mailhog_client, mail_template, clean_up):
     """
     Checks that the total number of matching emails is three.


### PR DESCRIPTION
There is new mark 'sandbag' and new target 'speedrun'. Both are supposed
to work together to enable fast test executin by skipping 'troublesome'
tests (slow, complex setup, ...). This will help with testing other
environments.