### PR TITLE
Refactor test_email_accounts.py

### DIFF
--- a/testsuite/tests/system/messages/test_email_accounts.py
+++ b/testsuite/tests/system/messages/test_email_accounts.py
@@ -15,7 +15,7 @@ from testsuite import rawobj
 from testsuite.utils import blame
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def application(service, custom_application, custom_app_plan, lifecycle_hooks, request):
     "application bound to the account and service with specific description that don't break yaml parsing"
     plan = custom_app_plan(rawobj.ApplicationPlan(blame(request, "aplan")), service)
@@ -26,7 +26,7 @@ def application(service, custom_application, custom_app_plan, lifecycle_hooks, r
     return app
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def mail_template(account, application, testconfig) -> dict:
     """loads the mail templates and substitutes the variables"""
     dirname = os.path.dirname(__file__)
@@ -48,61 +48,56 @@ def mail_template(account, application, testconfig) -> dict:
         return yaml.safe_load(yaml_string)
 
 
-def matching_emails(mailhog_client, mail_template):
-    """
-    Checks that the 'To', 'From' and 'Return-Path' addresses match the addresses from
-    the template
-    Checks that the message body and header matches one of the items in the template that
-    was not already matched. (The sent emails shouldn't be identical)
-    Returns the ids of the matching emails
-    """
-    ids = []
-    messages = mailhog_client.messages()
-    checked_messages = []
-    for message in messages['items']:
-        message_body = message["Content"]["Body"]\
-            .replace("=\r\n", "").replace("\r\n", "")
-        headers = message["Content"]["Headers"]
-        is_message_valid = False
-        are_headers_valid = True
-        for address_type in ["To", "From", "Return-Path"]:
-            try:
-                if headers[address_type][0] != mail_template["equal_templates"][address_type]:
-                    are_headers_valid = False
-                    break
-            except KeyError:
-                are_headers_valid = False
-        if are_headers_valid:
-            for template in mail_template["subject_templates"].values():
-                match_body = re.fullmatch(template["Body"], message_body)
-                match_headers = re.fullmatch(template["Headers"], headers["X-SMTPAPI"][0])
-                if match_body and match_headers and template["Body"] not in checked_messages:
-                    is_message_valid = True
-                    checked_messages.append(template["Body"])
-                    break
-
-            if is_message_valid:
-                ids.append(message["ID"])
-    return ids
+def headers(msg, filter_keys=None):
+    """Mailhog message headers with optional filtering"""
+    return {
+        k: ", ".join(v)
+        for k, v in msg["Content"]["Headers"].items()
+        if (not filter_keys or k in filter_keys)
+    }
 
 
-@pytest.fixture
-def clean_up(mailhog_client, mail_template):
-    """
-    cleans up the emails after the test execution
-    """
-    yield
-    ids = matching_emails(mailhog_client, mail_template)
-    mailhog_client.delete(ids)
+def body(msg):
+    """Mailhog message body"""
+    return msg["Content"]["Body"].replace("=\r\n", "").replace("\r\n", "")
+
+
+def message_match(tpl, key, text):
+    """True if text matches tpl for the key"""
+    for i in tpl["subject_templates"].values():
+        if re.fullmatch(i[key], text):
+            return True
+    return False
 
 
 # requires mailhog *AND* special deployment with preconfigured smtp secret
 # pylint: disable=unused-argument
 @backoff.on_exception(backoff.fibo, AssertionError, 8, jitter=None)
 @pytest.mark.sandbag
-def test_emails_after_account_creation(mailhog_client, mail_template, clean_up):
+def test_emails_after_account_creation(mailhog_client, mail_template):
     """
     Checks that the total number of matching emails is three.
     """
-    ids = matching_emails(mailhog_client, mail_template)
-    assert len(ids) == 3, f"Expected to find 3 emails, found {len(ids)}"
+    tpl = mail_template  # safe few letters
+
+    messages = mailhog_client.messages()["items"]
+    assert messages, "Mailhog inbox is empty"
+
+    messages = [m for m in messages if message_match(tpl, "Headers", headers(m)["X-SMTPAPI"])]
+    assert messages, f"Didn't find assumed X-SMTPAPI: {tpl['Headers']}"
+
+    messages = [m for m in messages if headers(m, filter_keys=tpl["equal_templates"].keys()) == tpl["equal_templates"]]
+    assert messages, f"Didn't find any email sent to expected account identified by {tpl['equal_templates']}"
+
+    messages = [m for m in messages if message_match(tpl, "Body", body(m))]
+    assert len(messages) == 3
+
+    # Yeah! Cleanup in the test. This shouldn't be here because it won't clean
+    # in case of failure. A reason to have it here is the fact that this
+    # version of test doesn't contain separate function to filter tested
+    # message (probably the author was lazy), also separate function scoped can
+    # be dangerous due to backoff/flakiness. On the other hand it isn't that
+    # "devastating" if messages are not cleaned as the mailhog receives too
+    # many other emails and it is flooded anyway. However better implementation
+    # with cleanup in fixture is highly desirable.
+    mailhog_client.delete([m["ID"] for m in messages])


### PR DESCRIPTION
It is absolutely fine to reject this PR (however great idea to accept it) and the reason is (at least) cleanup in the test itself.
Anyway I still prefer to accept it as it is much easier to understand this version in my opinion (what is very subjective and may be another reason for rejection actually) and should be way much easier to debug (though the reporting/logging is still sub-optimal). Currently the test is flaky, this was the impulse to rewrite it, however I believe I can fix also original test in case of rejection.

It was bit difficult to understand the original code. While this
proposal might be hard to read as well for someone, I believe its flow
is much easier to follow and particular checks should be clearer.

Furthermore fixtures are now module-scoped, this is because of
backoff/flakiness. In this particular case it is not desirable to repeat
setup/cleanup each time test is executed, what ma be a risk in case of
function scoped fixtures.