### PR TITLE
Change the way amp_release is gathered for custom apicast deployments

### DIFF
--- a/testsuite/tests/apicast/parameters/test_modular_apicast.py
+++ b/testsuite/tests/apicast/parameters/test_modular_apicast.py
@@ -25,7 +25,7 @@ def image_stream_name(request):
 
 
 @pytest.fixture(scope="module")
-def build_images(openshift, request, image_stream_name):
+def build_images(openshift, testconfig, request, image_stream_name):
     """
     Builds images defined by a template specified in the image template applied with parameter
     amp_release.
@@ -39,7 +39,7 @@ def build_images(openshift, request, image_stream_name):
     github_template = resources.files('testsuite.resources.modular_apicast').joinpath("example_policy.yml")
     copy_template = resources.files('testsuite.resources.modular_apicast').joinpath("example_policy_copy.yml")
 
-    amp_release = openshift_client.image_stream_tag("amp-apicast")
+    amp_release = testconfig["threescale"]["version"]
     build_name_github = blame(request, "apicast-example-policy-github")
     build_name_copy = blame(request, "apicast-example-policy-copy")
 

--- a/testsuite/tests/apicast/policy/on_failed/test_onfailed_custom_policy.py
+++ b/testsuite/tests/apicast/policy/on_failed/test_onfailed_custom_policy.py
@@ -26,7 +26,7 @@ def image_stream_name(request):
 
 
 @pytest.fixture(scope="module")
-def build_images(openshift, request, image_stream_name):
+def build_images(openshift, testconfig, request, image_stream_name):
     """
     Builds images defined by a template specified in the image template applied with parameter
     amp_release.
@@ -39,7 +39,7 @@ def build_images(openshift, request, image_stream_name):
 
     github_template = resources.files('testsuite.resources.modular_apicast').joinpath("example_policy.yml")
 
-    amp_release = openshift_client.image_stream_tag("amp-apicast")
+    amp_release = testconfig["threescale"]["version"]
     build_name_github = blame(request, "apicast-example-policy-github")
 
     github_params = {"AMP_RELEASE": amp_release,


### PR DESCRIPTION
Original implementation to gather version from imagestream caused
troubles during upgrades as upgraded deployment had two imagestreams
actually.