### PR TITLE
Repair of auth tests

### DIFF
--- a/testsuite/tests/ui/auth/test_provider.py
+++ b/testsuite/tests/ui/auth/test_provider.py
@@ -19,4 +19,4 @@ def test_provider(navigator, login, request):
     """
     request.getfixturevalue(login)
     admin_view = navigator.navigate(BaseAdminView)
-    assert admin_view.is_displayed
+    assert admin_view.wait_displayed()

--- a/testsuite/tests/ui/conftest.py
+++ b/testsuite/tests/ui/conftest.py
@@ -98,6 +98,7 @@ def custom_devel_login(browser, sessions, navigator, provider_account, account_p
     :param account_password: fixture that returns default account password
     :return: Login to Developer portal with custom credentials (account or name-password pair)
     """
+
     def _login(account=None, name=None, password=None):
         url = settings["threescale"]["devel"]["url"]
         name = name or account['org_name']
@@ -334,7 +335,7 @@ def custom_auth0_login(browser, navigator, threescale, request, testconfig):
 
 
 @pytest.fixture(scope="module")
-def custom_rhsso_login(browser, navigator, threescale, request, testconfig):
+def custom_rhsso_login(browser, navigator, threescale, request, testconfig, rhsso_service_info):
     """
     Login fixture for admin portal via RHSSO.
     :param browser: Browser instance
@@ -347,6 +348,8 @@ def custom_rhsso_login(browser, navigator, threescale, request, testconfig):
     def _login(username, password, rhsso_username=None):
         browser.selenium.delete_all_cookies()
         browser.refresh()
+        user_id = rhsso_service_info.realm.admin.get_user_id(username)
+        rhsso_service_info.realm.admin.logout(user_id)
         browser.url = settings["threescale"]["admin"]["url"]
         page = navigator.open(LoginView)
         page.do_rhsso_login(username, password)
@@ -388,13 +391,20 @@ def set_callback_urls(auth0_client):
     """
     Set callback urls for Auth0 application
     """
+    cleanup = []
 
-    @backoff.on_predicate(backoff.fibo, lambda x: not x, 8, jitter=None)
-    def _set_callback_urls(client_id, urls: list):
-        auth0_client.clients.update(client_id, body={"callbacks": urls})
+    @backoff.on_predicate(backoff.fibo, lambda x: not x['callbacks'], 8, jitter=None)
+    def _get_auth_client(client_id):
         return auth0_client.clients.get(client_id)
 
-    return _set_callback_urls
+    def _set_callback_urls(client_id, urls: list):
+        auth0_client.clients.update(client_id, body={"callbacks": urls})
+        cleanup.append(client_id)
+        return _get_auth_client(client_id)
+
+    yield _set_callback_urls
+    for client in cleanup:
+        auth0_client.clients.update(client, body={"callbacks": []})
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/ui/devel/auth/conftest.py
+++ b/testsuite/tests/ui/devel/auth/conftest.py
@@ -6,28 +6,41 @@ from testsuite import settings
 from testsuite.ui.views.devel.login import LoginDevelView
 
 
+# pylint: disable=too-many-arguments
 @pytest.fixture(scope="module")
-def custom_devel_auth0_login(browser, navigator, provider_account):
+def custom_devel_auth0_login(browser, navigator, provider_account, threescale, testconfig):
     """
     Login to Developer portal with specific account or credentials
     :param browser: Browser instance
     :param navigator: Navigator Instance
     :param provider_account: Currently used provider account (tenant)
+    :param threescale: 3scale API client
+    :param request: We need this to be able to delete automatic created user after tests.
     :return: Login to Developer portal with custom credentials via Auth0
     """
+    cleanup = []
 
     def _login(email, password):
+        browser.selenium.delete_all_cookies()
         url = settings["threescale"]["devel"]["url"]
         browser.url = url
         page = navigator.open(LoginDevelView,
                               access_code=provider_account['site_access_code'])
         page.do_auth0_login(email, password)
+        cleanup.append(email)
 
-    return _login
+    yield _login
+
+    if not testconfig["skip_cleanup"]:
+        for email in cleanup:
+            name = email.split("@")[0]
+            account = [x for x in threescale.accounts.list() if x.users.list()[0]['username'] == name][0]
+            account.delete()
 
 
+# pylint: disable=too-many-arguments
 @pytest.fixture(scope="module")
-def custom_devel_rhsso_login(browser, navigator, provider_account):
+def custom_devel_rhsso_login(browser, navigator, provider_account, threescale, testconfig):
     """
     Login to Developer portal with specific account or credentials
     :param browser: Browser instance
@@ -35,12 +48,20 @@ def custom_devel_rhsso_login(browser, navigator, provider_account):
     :param provider_account: Currently used provider account (tenant)
     :return: Login to Developer portal with custom credentials via RHSSO
     """
+    cleanup = []
 
-    def _login(name, password):
+    def _login(name, password, rhsso_username):
+        browser.selenium.delete_all_cookies()
         url = settings["threescale"]["devel"]["url"]
         browser.url = url
         page = navigator.open(LoginDevelView,
                               access_code=provider_account['site_access_code'])
         page.do_rhsso_login(name, password)
+        cleanup.append(rhsso_username)
 
-    return _login
+    yield _login
+
+    if not testconfig["skip_cleanup"]:
+        for username in cleanup:
+            account = [x for x in threescale.accounts.list() if x.users.list()[0]['username'] == username][0]
+            account.delete()

--- a/testsuite/tests/ui/devel/auth/test_login_auth0.py
+++ b/testsuite/tests/ui/devel/auth/test_login_auth0.py
@@ -52,7 +52,7 @@ def test_devel_login_auth0(custom_devel_auth0_login, navigator, auth0_user, auth
     """
     custom_devel_auth0_login(auth0_user["email"], auth0_user_password)
     signup_view = SignUpView(navigator.browser)
-    assert signup_view.wait_displayed
+    assert signup_view.wait_displayed()
 
     signup_view.signup("RedHat")
 

--- a/testsuite/ui/views/auth.py
+++ b/testsuite/ui/views/auth.py
@@ -1,7 +1,7 @@
 """View representations of 3rd party auth pages"""
 
 from weakget import weakget
-from widgetastic.widget import View, TextInput, GenericLocatorWidget
+from widgetastic.widget import View, TextInput, GenericLocatorWidget, Text
 
 from testsuite import settings
 from testsuite.ui.navigation import Navigable
@@ -15,17 +15,21 @@ class Auth0View(View, Navigable):
     password = TextInput(name="password")
     login_button = GenericLocatorWidget(locator="//button[@aria-label='Log In']")
     last_login_button = GenericLocatorWidget(locator="//*[contains(@class,'auth0-lock-social-button')]")
+    last_login_button_text = Text(locator="//*[contains(@class,'auth0-lock-social-button-text')]")
     not_my_account = GenericLocatorWidget(locator="//*[@class='auth0-lock-alternative-link']")
 
     def login(self, email, password):
         """Login to 3scale via Auth0"""
         self.last_login_button.wait_displayed()
-        if self.email.is_displayed:
-            self.email.fill(email)
-            self.password.fill(password)
-            self.login_button.click()
-        else:
-            self.last_login_button.click()
+        if not self.email.is_displayed:
+            if self.last_login_button_text.text == email:
+                self.last_login_button.click()
+                return
+            self.not_my_account.click()
+        self.email.wait_displayed()
+        self.email.fill(email)
+        self.password.fill(password)
+        self.login_button.click()
 
     @property
     def is_displayed(self):


### PR DESCRIPTION
Add sleep into auth0 setup due to slow auth0 API. Add missing cleanup to auth tests. Change scope of browser fixture for devel auth tests.
