### PR TITLE
Refresh CR before applying in OperatorApicast

### DIFF
--- a/testsuite/gateways/apicast/operator.py
+++ b/testsuite/gateways/apicast/operator.py
@@ -58,6 +58,9 @@ class OperatorEnviron(Properties):
             raise NotImplementedError(f"Env variable {name} doesn't exists or is not yet implemented in operator")
 
     def set_many(self, envs: Dict[str, str]):
+        # If the CR is updated and is out of sync with the one we have stored in memory, it might not apply the patch
+        # correctly, refreshing before applying our changes is not 100% solution but should make this more stable
+        self.apicast.refresh()
         for name, value in envs.items():
             self._set(name, value, commit=False)
         self.apicast.apply()


### PR DESCRIPTION
This should fix failures in `test_http_proxy` and make operator tests more stable. It is not 100% solution, that would be rewriting everything to use `modify_and_apply()` but that would require changing a lot more things.