### PR TITLE
Return back to image stream tag

### DIFF
--- a/testsuite/dynaconf_loader.py
+++ b/testsuite/dynaconf_loader.py
@@ -53,12 +53,10 @@ def _guess_version(ocp):
 
     version = None
     try:
-        config = ocp.do_action("get", ["dc/apicast-production", "-o", "yaml"], parse_output=True)
-        version = [trigger.imageChangeParams["from"]["name"].split(":", 1)[1]
-                   for trigger in config.model.spec.triggers if trigger.type == "ImageChange"][0]
+        version = ocp.image_stream_tag_from_trigger("dc/apicast-production")
         Version(version)
-    except (IndexError, OpenShiftPythonException, InvalidVersion):
-        return _testsuite_version().split("-")[0]
+    except (ValueError, IndexError, OpenShiftPythonException, InvalidVersion):
+        return ".".join(_testsuite_version().split(".")[:2])
 
     return str(version)
 

--- a/testsuite/openshift/client.py
+++ b/testsuite/openshift/client.py
@@ -436,6 +436,14 @@ class OpenShiftClient:
         """
         self.do_action("start-build", [build_name, "--wait=true"])
 
+    def image_stream_tag_from_trigger(self, name):
+        """Gather tag from trigger of given obj name e.g. dc/something"""
+        obj = self.do_action("get", [name, "-o", "yaml"], parse_output=True)
+        for trigger in obj.model.spec.triggers:
+            if trigger.type == "ImageChange":
+                return trigger.imageChangeParams["from"]["name"].split(":", 1)[1]
+        raise ValueError(f"{obj} without ImageChange trigger")
+
     def image_stream_tag(self, image_stream):
         """
         Gets the tag of the given imagestream

--- a/testsuite/tests/apicast/parameters/test_modular_apicast.py
+++ b/testsuite/tests/apicast/parameters/test_modular_apicast.py
@@ -25,7 +25,7 @@ def image_stream_name(request):
 
 
 @pytest.fixture(scope="module")
-def build_images(openshift, testconfig, request, image_stream_name):
+def build_images(openshift, request, image_stream_name):
     """
     Builds images defined by a template specified in the image template applied with parameter
     amp_release.
@@ -39,7 +39,7 @@ def build_images(openshift, testconfig, request, image_stream_name):
     github_template = resources.files('testsuite.resources.modular_apicast').joinpath("example_policy.yml")
     copy_template = resources.files('testsuite.resources.modular_apicast').joinpath("example_policy_copy.yml")
 
-    amp_release = testconfig["threescale"]["version"]
+    amp_release = openshift_client.image_stream_tag_from_trigger("dc/apicast-production")
     build_name_github = blame(request, "apicast-example-policy-github")
     build_name_copy = blame(request, "apicast-example-policy-copy")
 

--- a/testsuite/tests/apicast/policy/on_failed/test_onfailed_custom_policy.py
+++ b/testsuite/tests/apicast/policy/on_failed/test_onfailed_custom_policy.py
@@ -26,7 +26,7 @@ def image_stream_name(request):
 
 
 @pytest.fixture(scope="module")
-def build_images(openshift, testconfig, request, image_stream_name):
+def build_images(openshift, request, image_stream_name):
     """
     Builds images defined by a template specified in the image template applied with parameter
     amp_release.
@@ -39,7 +39,7 @@ def build_images(openshift, testconfig, request, image_stream_name):
 
     github_template = resources.files('testsuite.resources.modular_apicast').joinpath("example_policy.yml")
 
-    amp_release = testconfig["threescale"]["version"]
+    amp_release = openshift_client.image_stream_tag_from_trigger("dc/apicast-production")
     build_name_github = blame(request, "apicast-example-policy-github")
 
     github_params = {"AMP_RELEASE": amp_release,


### PR DESCRIPTION
Few tests using custom apicast need amp release version for apicast
template. Original code using image stream tag didnt handle multiple
streams (e.g. after upgrade). The attempt to replace it with version
didnt work either as some delpoyment (devel versions) do not have
versioned images yet.

This is another one attempt again with images stream tag, however now
gathered from trigger in the deployment config.

Besides that version gathering in dynaconf_loader was updated to used
shared code (current version is based on what was there)