### PR TITLE
Avoid explicit API backend in smoke tests

### DIFF
--- a/testsuite/tests/apicast/policy/headers/test_headers_policy_add.py
+++ b/testsuite/tests/apicast/policy/headers/test_headers_policy_add.py
@@ -37,7 +37,6 @@ def test_headers_policy_doesnt_exist(api_client):
     assert "X-Request-Custom-Add" not in echoed_request.headers
 
 
-@pytest.mark.smoke
 def test_headers_policy_another_value_to_request(api_client):
     """ must add another value to the existing header of the request """
     response = api_client().get("/get", headers={'X-REQUEST-CUSTOM-ADD': 'Original header'})

--- a/testsuite/tests/apicast/policy/headers/test_headers_policy_liquid_set.py
+++ b/testsuite/tests/apicast/policy/headers/test_headers_policy_liquid_set.py
@@ -24,6 +24,7 @@ def policy_settings():
                      }]})
 
 
+@pytest.mark.smoke
 def test_header_policy_add_to_response_with_liquid_service_id_api_client(api_client, service):
     """must add header to response using the liquid - service id should be expanded"""
     liquid_value = f"Service_id {service.entity_id}"

--- a/testsuite/tests/apicast/policy/headers/test_headers_policy_push_headers.py
+++ b/testsuite/tests/apicast/policy/headers/test_headers_policy_push_headers.py
@@ -30,7 +30,6 @@ def policy_settings():
                      "value": "Additional request header"}]})
 
 
-@pytest.mark.smoke
 def test_headers_policy_function(api_client):
     """testing custom header policy"""
     response = api_client().get('/get')

--- a/testsuite/tests/apicast/policy/routing/test_routing_policy_path.py
+++ b/testsuite/tests/apicast/policy/routing/test_routing_policy_path.py
@@ -64,7 +64,6 @@ def service(service, private_base_url, httpbin_host):
     return service
 
 
-@pytest.mark.smoke
 def test_routing_policy_path_anything(api_client, httpbin_host):
     """
     Test for the request path send to /anything to httpbin.org/anything

--- a/testsuite/tests/apicast/policy/routing/test_routing_policy_replace_path.py
+++ b/testsuite/tests/apicast/policy/routing/test_routing_policy_replace_path.py
@@ -7,14 +7,6 @@ from testsuite.echoed_request import EchoedRequest
 
 
 @pytest.fixture(scope="module")
-def service_proxy_settings(private_base_url):
-    """
-    Require compatible backend to be used
-    """
-    return rawobj.Proxy(private_base_url("echo_api"))
-
-
-@pytest.fixture(scope="module")
 def service(service, private_base_url):
     """
     Sets routing policy configuration to service
@@ -25,13 +17,14 @@ def service(service, private_base_url):
     proxy = service.proxy.list()
     proxy.policies.insert(0, rawobj.PolicyConfig("routing", {
         "rules": [
-            {"url": private_base_url("primary"),
+            {"url": private_base_url(),
              "condition": routing_policy_op,
              "replace_path": "{{ original_request.path | remove_first: '/anything' }}"}]}))
 
     return service
 
 
+@pytest.mark.smoke
 @pytest.mark.issue("https://issues.jboss.org/browse/THREESCALE-3593")
 def test_routing_policy_replace_path(api_client):
     """


### PR DESCRIPTION
For better interoperability smoke tests shouldnt expect any special
backend and they should work with default well.