### PR TITLE
Mockserver instead of httpbin, requestbin and tinyproxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ configuration points to some publicly available services. However it is
 **highly desirable** to deploy own instance(s) of suitable service and change
 configuration to use this (through `config/settings.local.yaml`
 
+Backend APIs are referenced by service name in the settings, e.g. 'httpbin',
+'httpbin_nossl'. These names are used (and kept unchanged) for historical
+reason to avoid breaking of defined usage. In fact they don't represent
+specific service, but rather an 'interface' of such service implemting its
+calls.
+
 ### make tools
 
 Container image can be built with script that provisions necessary
@@ -113,13 +119,11 @@ set in configuration.
 
 Here is the list of services:
 
- * docker.io/eloycoto/apicast:tinyproxy
  * docker.io/jaegertracing/all-in-one:latest
  * docker.io/jsmadis/go-httpbin:latest
- * docker.io/jsmadis/httpbin:latest
  * docker.io/mailhog/mailhog:latest
  * docker.io/prom/prometheus
- * docker.io/sxmichael/requestbin:latest
+ * quay.io/mganisin/mockserver:latest
  * quay.io/rh_integration/3scale-fuse-camel-proxy:latest
  * quay.io/3scale/echoapi:stable
  * registry.redhat.io/rhscl/redis-32-rhel7:3.2

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -5,7 +5,6 @@ default:
   threescale:
     service:
       backends:
-        primary: https://echo-api.3scale.net:443
         httpbin: https://httpbin.org:443
         echo_api: https://echo-api.3scale.net:443
         httpbin_nossl: http://httpbin.org:80

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -25,8 +25,8 @@ default:
   redis:
     url: redis://apicast-testing-redis:6379/1
   proxy:
-    http: "@format http://tinyproxy-service.{this.FIXTURES.tools.namespace}.svc:8888"
-    https: "@format http://tinyproxy-service.{this.FIXTURES.tools.namespace}.svc:8888"
+    http: "@format http://mockserver.{this.FIXTURES.tools.namespace}.svc:1080"
+    https: "@format http://mockserver.{this.FIXTURES.tools.namespace}.svc:1080"
   toolbox:
     cmd: "podman"
     podman_cert_dir: "/var/data"

--- a/testsuite/mockserver.py
+++ b/testsuite/mockserver.py
@@ -1,0 +1,65 @@
+"""Represents mockserver calls used in tests"""
+from urllib.parse import urljoin
+import json
+
+from weakget import weakget
+import backoff
+import requests
+
+from testsuite.utils import generate_tail
+
+
+class Mockserver:
+    """mockserver interface
+
+    Also implements RequestBinClient interface to replace requestbin. Therefore
+    `url` attribute returns URL suitable for webhooks instead of own URL. `url`
+    is randomized per instance to a) make matching bit easier, b) allow
+    bit of concurrency.
+    """
+    def __init__(self, url):
+        self._url = url
+        self._webhook = f"/webhook/{generate_tail()}"
+        self.url = urljoin(self._url, self._webhook)
+
+    def temporary_fail_request(self, num, status=500):
+        """Create failing call for num occurences"""
+        response = requests.put(urljoin(self._url, "/mockserver/expectation"), verify=False, data=json.dumps(
+            {
+                "httpRequest": {"path": f"/fail-request/{num}/{status}"},
+                "times": {"remainingTimes": num, "unlimited": False},
+                "httpResponse": {"statusCode": status}
+            }
+        ))
+        response.raise_for_status()
+        return response
+
+    @backoff.on_predicate(backoff.fibo, lambda x: x is None, max_tries=5, jitter=None)
+    def get_webhook(self, action: str, entity_id: str):
+        """
+        Reimplementation of interface from RequestBinClient
+        :return webhook for given action and entity_id
+        """
+        try:
+            matcher = {
+                "method": "POST",
+                "path": self._webhook,
+                "body": {
+                    "type": "XPATH",
+                    # this is xpath, it's long
+                    # pylint: disable=line-too-long
+                    "xpath": f'/event[action/text() = "{action}"]/object/*[local-name() = /event/type/text()]/id[text() = "{entity_id}"]'}  # noqa
+            }
+            response = self._retrieve(matcher)
+        except requests.exceptions.HTTPError:
+            return None
+        return weakget(response.json())[0]["httpRequest"]["body"]["xml"] % None
+
+    def _retrieve(self, matcher):
+        """Do mockserver/retrieve"""
+        response = requests.put(
+            urljoin(self._url, "/mockserver/retrieve"),
+            params={"type": "REQUEST_RESPONSES"},
+            data=json.dumps(matcher))
+        response.raise_for_status()
+        return response

--- a/testsuite/tests/apicast/parameters/http_proxy/test_http_proxy.py
+++ b/testsuite/tests/apicast/parameters/http_proxy/test_http_proxy.py
@@ -6,6 +6,7 @@ Apicast should use all traffic through the defined proxy via HTTP_PROXY env var.
 import pytest
 
 from testsuite import rawobj
+from testsuite.echoed_request import EchoedRequest
 from testsuite.capabilities import Capability
 from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 
@@ -39,7 +40,7 @@ def test_proxied_request(api_client, private_base_url):
     response = api_client().get("/headers")
     assert response.status_code == 200
 
-    headers = response.json()["headers"]
+    headers = EchoedRequest.create(response).headers
 
     assert "Fuse-Camel-Proxy" in headers
     assert headers["Source-Header"] in private_base_url("httpbin_service")

--- a/testsuite/tests/apicast/policy/proxy/test_proxy_service_policy.py
+++ b/testsuite/tests/apicast/policy/proxy/test_proxy_service_policy.py
@@ -7,6 +7,7 @@ Proxy service is simple camel route, that adds "Fuse-Camel-Proxy" header to the 
 import pytest
 
 from testsuite import rawobj
+from testsuite.echoed_request import EchoedRequest
 
 
 @pytest.fixture(scope="module")
@@ -38,6 +39,6 @@ def test_http_proxy_policy(api_client, private_base_url):
     """
     response = api_client().get("/headers")
     assert response.status_code == 200
-    headers = response.json()["headers"]
+    headers = EchoedRequest.create(response).headers
     assert "Fuse-Camel-Proxy" in headers
     assert headers["Source-Header"] in private_base_url("httpbin_service")

--- a/testsuite/tests/apicast/policy/routing/test_routing_policy_replace_path.py
+++ b/testsuite/tests/apicast/policy/routing/test_routing_policy_replace_path.py
@@ -7,14 +7,6 @@ from testsuite.echoed_request import EchoedRequest
 
 
 @pytest.fixture(scope="module")
-def service_proxy_settings(private_base_url):
-    """
-    Require compatible backend to be used
-    """
-    return rawobj.Proxy(private_base_url("echo_api"))
-
-
-@pytest.fixture(scope="module")
 def service(service, private_base_url):
     """
     Sets routing policy configuration to service
@@ -25,7 +17,7 @@ def service(service, private_base_url):
     proxy = service.proxy.list()
     proxy.policies.insert(0, rawobj.PolicyConfig("routing", {
         "rules": [
-            {"url": private_base_url("primary"),
+            {"url": private_base_url(),
              "condition": routing_policy_op,
              "replace_path": "{{ original_request.path | remove_first: '/anything' }}"}]}))
 

--- a/testsuite/tests/apicast/test_strip_standard_https_ports.py
+++ b/testsuite/tests/apicast/test_strip_standard_https_ports.py
@@ -57,7 +57,7 @@ def test_strip_ports(api_client, private_base_url_and_expected_port):
     client = api_client()
     response = client.get("/get")
 
-    echoed_request = EchoedRequest(response)
+    echoed_request = EchoedRequest.create(response)
 
     url_split = echoed_request.headers['host'].split(":")
 

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -21,8 +21,8 @@ from testsuite import rawobj, HTTP2, gateways, configuration
 from testsuite.capabilities import Capability, CapabilityRegistry
 from testsuite.config import settings
 from testsuite.prometheus import PrometheusClient
-from testsuite.requestbin import RequestBinClient
 from testsuite.httpx import HttpxHook
+from testsuite.mockserver import Mockserver
 from testsuite.rhsso.objects import Realm
 from testsuite.utils import blame, blame_desc, warn_and_skip
 from testsuite.rhsso import RHSSOServiceConfiguration, RHSSO
@@ -785,7 +785,7 @@ def requestbin(testconfig, tools):
     """
     Returns an instance of RequestBin.
     """
-    return RequestBinClient(weakget(testconfig)["requestbin"]["url"] % tools["request-bin"])
+    return Mockserver(tools["mockserver"])
 
 
 @pytest.fixture(scope="session")

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -467,11 +467,11 @@ def private_base_url(testconfig, tools):
     Args:
         :param kind: Desired type of backend; possible values 'primary' (default), 'httpbin', 'echo-api'"""
 
-    primary = weakget(testconfig)["fixtures"]["private_base_url"]["default"] % "echo_api"
+    default = weakget(testconfig)["fixtures"]["private_base_url"]["default"] % "echo-api"
+    special = weakget(testconfig)["fixtures"]["private_base_url"]["special"] % "mockserver"
 
-    def _private_base_url(kind="primary"):
-        if kind == "primary":
-            kind = primary
+    def _private_base_url(kind="default+ssl"):
+        kind = kind.replace("default", default).replace("special", special)
         return tools[kind]
 
     return _private_base_url

--- a/testsuite/tools.py
+++ b/testsuite/tools.py
@@ -1,9 +1,24 @@
 # pylint: disable=too-few-public-methods,broad-except
 
-"""This provides interface to get test environment tools
+"""
+This provides interface to get test environment tools
 
 Different sources can be used, e.g. if deployed in openshift tools can be gathered
-from openshift namespace/project."""
+from openshift namespace/project.
+
+Historically "symbolic" names used as config keys in settings use name of
+particular service e.g. 'httpbin'. This was never 100% accurate as the service
+shouldn't represent a specific implementation but rather available upstream
+API. It's better to think about these names as desired interface of the
+upstream API. Even that is simplified, because all the services used as
+upstream API have standardized interface thanks to EchoedRequest.
+
+So 'httpbin' key doesn't represent the httpbin instance, but rather a upstream
+API implementing calls of httpbin.
+
+Note: It may be good idea to consider change of all these keys to something
+abstract, however that would cause huge disruption in usage of the testsuite.
+"""
 
 # This uses direct access to testsuite settings and configuration objects. The
 # difference is that this is integral part of the testsuite and has zero chance
@@ -15,10 +30,10 @@ from testsuite.configuration import openshift
 
 _tr = {
     "echo_api": "echo-api+ssl",
-    "httpbin": "httpbin+ssl",
-    "httpbin_nossl": "httpbin",
+    "httpbin": "mockserver+ssl",
+    "httpbin_nossl": "mockserver",
     "httpbin_go": "go-httpbin+ssl",
-    "httpbin_service": "httpbin+svc",
+    "httpbin_service": "echo-api+svc:9292",
     "httpbin_go_service": "go-httpbin+svc",
     "jaeger": "jaeger-query"}
 


### PR DESCRIPTION
This eliminates 3 services, replaced by one. Few other still remain (echo-api, go-httpbin), likely echo-api will stay there (as at least two services is needed), go-httbin implements http/2 and websockets, this is missing in mockserver now.

This PR is split into couple of commits, worth to review commit by commit. The change is relatively small with minimum of necessary changes to make the switch possible.