### PR TITLE
Explicit zipp dependency for importlib_resources

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ types-paramiko = "*"
 [packages]
 typing_extensions = "*"
 importlib_resources = "*"
+zipp = "*"
 pytest-xdist = "*"
 pytest = "*"
 pytest-cases = "*"


### PR DESCRIPTION
importlib_resources (on python3.8) cant be importted because of missing
zipp, maybe broken dependency