### PR TITLE
Fix TLS UI test (again)

### DIFF
--- a/testsuite/tests/ui/policies/test_tls_termination_policy_in_ui.py
+++ b/testsuite/tests/ui/policies/test_tls_termination_policy_in_ui.py
@@ -16,7 +16,7 @@ from testsuite.utils import blame
 
 # Imports for TLS fixtures
 from testsuite.tests.apicast.policy.tls.conftest import require_openshift, staging_gateway, mount_certificate_secret, \
-    valid_authority, certificate, create_cert, server_authority # noqa # pylint: disable=unused-import
+    valid_authority, certificate, create_cert, server_authority, manager, superdomain # noqa # pylint: disable=unused-import
 
 pytestmark = [
     pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),


### PR DESCRIPTION
Most likely #80 broke (over a month ago!) but since it is a UI test that is not run very frequently it is hard to notice and the static checkers fail to notice as well.