### PR TITLE
Base certificate hostname on api url

### DIFF
--- a/testsuite/openshift/client.py
+++ b/testsuite/openshift/client.py
@@ -45,6 +45,13 @@ class OpenShiftClient:
             stack.enter_context(oc.token(self.token))
         stack.enter_context(oc.project(self.project_name))
 
+    @property
+    def api_url(self):
+        """Returns real API url"""
+        with ExitStack() as stack:
+            self.prepare_context(stack)
+            return oc.whoami("--show-server=true")
+
     def do_action(self, verb: str, cmd_args: Sequence[Union[str, Sequence[str]]] = None,
                   auto_raise: bool = True, parse_output: bool = False):
         """Run an oc command."""

--- a/testsuite/tests/apicast/policy/tls/tls_upstream/conftest.py
+++ b/testsuite/tests/apicast/policy/tls/tls_upstream/conftest.py
@@ -1,6 +1,8 @@
 """
 Configuration for tests making use of an upstream supporting TLS
 """
+from urllib.parse import urlparse
+
 import pytest
 
 import importlib_resources as resources
@@ -20,12 +22,13 @@ def upstream_authority(valid_authority):
 
 
 @pytest.fixture(scope="module")
-def upstream_cert_hostname(superdomain):
+def upstream_cert_hostname(staging_gateway):
     """
     Hostname of the upstream certificate sent to be validated by APIcast
     May be overwritten to configure different test cases
     """
-    return "*." + superdomain.split(".", 1)[1]
+    hostname = urlparse(staging_gateway.openshift.api_url).hostname
+    return "*.apps" + hostname.split(".", 1)[1]
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/policy/tls/tls_upstream/mtls_upstream_cert_validation/test_upstream_mtls_policy_upstream_cert_validation.py
+++ b/testsuite/tests/apicast/policy/tls/tls_upstream/mtls_upstream_cert_validation/test_upstream_mtls_policy_upstream_cert_validation.py
@@ -7,6 +7,7 @@ Second the ca_certificates contains mismatched certificates, which should fail w
 refusing to accept the other certificate.
 Third the no certificates are specified in ca_certificates, in which case APIcast returns 200
 """
+from urllib.parse import urlparse
 
 import pytest
 
@@ -34,11 +35,13 @@ def apicast_certificate(certificate):
 
 
 @pytest.fixture(scope="module")
-def valid_upstream_hostname(superdomain):
+def valid_upstream_hostname(staging_gateway):
     """
-    Upstream hostname matching the upstream domain name
+    Upstream hostname matching the upstream domain name based on API server url
+    Note: This will work only on OpenShift with default settings for API and apps URL
     """
-    return "*." + superdomain.split(".", 1)[1]
+    hostname = urlparse(staging_gateway.openshift.api_url).hostname
+    return "*.apps." + hostname.split(".", 1)[1]
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Previous implementation derived the hostname from 3scale superdomain and expected 3scale to be configured in a specific way. This PR changes that to make this work on any 3scale configuration as long as the OpenShift has standard URLs (api.<cluster_superdomain> and apps.<cluster_superdomain>)

@mganisin It should fix the failure both with RHOAM and IBM