### PR TITLE
Add longer wait time to test_custom_tenant

### DIFF
--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -283,7 +283,7 @@ def threescale(testconfig):
         testconfig["threescale"]["admin"]["url"],
         testconfig["threescale"]["admin"]["token"],
         ssl_verify=testconfig["ssl_verify"],
-        wait=True
+        wait=16
     )
 
 

--- a/testsuite/tests/custom_tenant/test_custom_tenant.py
+++ b/testsuite/tests/custom_tenant/test_custom_tenant.py
@@ -12,7 +12,7 @@ def threescale(custom_tenant, testconfig):
     the new tenant
     """
     tenant = custom_tenant()
-    return tenant.admin_api(ssl_verify=testconfig["ssl_verify"], wait=True)
+    return tenant.admin_api(ssl_verify=testconfig["ssl_verify"], wait=32)
 
 
 # FIXME: threescale_api.errors.ApiClientError: Response(422): b'{"errors":{"system_name":["must be shorter."]}}


### PR DESCRIPTION
client library has changed to allow custom wait time in client
initialization (needed because of various 40x errors before fresh
3scale/tenant is fully initialized). So let's extend waiting time,
because original period wasn't enough under our conditions.