### PR TITLE
Add test to verify labels on operator pod

### DIFF
--- a/testsuite/openshift/client.py
+++ b/testsuite/openshift/client.py
@@ -389,7 +389,8 @@ class OpenShiftClient:
         :return: the operator pod
         """
         def select_operator(apiobject):
-            return apiobject.get_label("com.redhat.component-name") == "3scale-operator"
+            return apiobject.get_label("com.redhat.component-name") == "3scale-operator" \
+                or apiobject.get_label("rht.subcomp") == "3scale_operator"
 
         return self.select_resource("pods", narrow_function=select_operator)
 

--- a/testsuite/tests/operator/test_labels.py
+++ b/testsuite/tests/operator/test_labels.py
@@ -1,0 +1,63 @@
+"""
+Check if labels of operator pod are present
+"""
+from typing import Tuple, List, Union
+
+import pytest
+from packaging.version import Version  # noqa # pylint: disable=unused-import
+
+from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite.capabilities import Capability
+from testsuite.configuration import openshift
+
+pytestmark = [
+    pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-7750"),
+    pytest.mark.required_capabilities(Capability.OCP4),
+]
+
+LABELS_PRE_2_12: List[Union[Tuple[str, str], Tuple[str, None]]] = [
+    ("com.redhat.component-name", "3scale-operator"),
+    ("com.redhat.component-type", "infrastructure"),
+    ("com.redhat.component-version", None),
+    ("com.redhat.product-name", "3scale"),
+    ("com.redhat.product-version", None),
+    ("control-plane", "controller-manager"),
+]
+
+LABELS_POST_2_12: List[Union[Tuple[str, str], Tuple[str, None]]] = [
+    ("com.company", "Red_Hat"),
+    ("control-plane", "controller-manager"),
+    ("rht.comp", "3scale"),
+    ("rht.comp_ver", None),
+    ("rht.prod_name", "Red_Hat_Integration"),
+    ("rht.prod_ver", None),
+    ("rht.subcomp", "3scale_operator"),
+    ("rht.subcomp_t", "infrastructure"),
+]
+
+
+@pytest.fixture(scope="session")
+def operator():
+    """Return operator pod object."""
+    pod = openshift().get_operator().object()
+    return pod
+
+
+@pytest.mark.skipif("TESTED_VERSION >= Version('2.12')")
+@pytest.mark.parametrize("label,expected_value", LABELS_PRE_2_12)
+def test_labels_operator_old(label, expected_value, operator):
+    """ Test labels of operator pod. """
+    value = operator.get_label(label)
+    assert value is not None
+    if expected_value:
+        assert value == expected_value
+
+
+@pytest.mark.skipif("TESTED_VERSION < Version('2.12')")
+@pytest.mark.parametrize("label,expected_value", LABELS_POST_2_12)
+def test_labels_operator_new(label, expected_value, operator):
+    """ Test labels of operator pod. """
+    value = operator.get_label(label)
+    assert value is not None
+    if expected_value:
+        assert value == expected_value


### PR DESCRIPTION
https://github.com/3scale/3scale-operator/pull/679 is redefining labels for 3scale operator. This MR is updating selector for operator pod.
New test is introduced that will verify label presence.