### PR TITLE
Add APICAST capability to test_batching_caching_policy.py

### DIFF
--- a/testsuite/tests/prometheus/apicast/selfmanaged/test_batching_caching_policy.py
+++ b/testsuite/tests/prometheus/apicast/selfmanaged/test_batching_caching_policy.py
@@ -10,7 +10,7 @@ from testsuite.capabilities import Capability
 
 pytestmark = [
     pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
-    pytest.mark.required_capabilities(Capability.OCP4),
+    pytest.mark.required_capabilities(Capability.OCP4, Capability.APICAST),
     ]
 
 BATCH_REPORT_SECONDS = 50


### PR DESCRIPTION
* Missing APICAST capability meant that it was run even when Service Mesh was configured