### PR TITLE
Extract Deployment related methods into separate module

### DIFF
--- a/testsuite/dynaconf_loader.py
+++ b/testsuite/dynaconf_loader.py
@@ -80,7 +80,7 @@ def _rhsso_password(server_url, token):
             # was it deployed as part of tools?
             tools = OpenShiftClient(
                 project_name="tools", server_url=server_url, token=token)
-            return tools.environ("sso")["SSO_ADMIN_PASSWORD"]
+            return tools.environ("dc/sso")["SSO_ADMIN_PASSWORD"]
         except (OpenShiftPythonException, KeyError):
             return None
 

--- a/testsuite/gateways/apicast/operator.py
+++ b/testsuite/gateways/apicast/operator.py
@@ -124,7 +124,7 @@ class OperatorApicast(SelfManagedApicast):
 
     @property
     def deployment(self):
-        return f"apicast-{super().deployment}"
+        return self.openshift.deployment(f"deployment/apicast-{self.name}")
 
     @property
     def environ(self) -> Properties:
@@ -133,10 +133,7 @@ class OperatorApicast(SelfManagedApicast):
         return self._environ
 
     def reload(self):
-        self.openshift.do_action("delete", ["pod", "--force",
-                                            "--grace-period=0", "-l", f"deployment={self.deployment}"])
-        # pylint: disable=protected-access
-        self.openshift.wait_for_ready(self.deployment)
+        self.deployment.rollout()
 
     def create(self):
         apicast = APIcast.create_instance(
@@ -158,7 +155,7 @@ class OperatorApicast(SelfManagedApicast):
         # is created
         time.sleep(2)
         # pylint: disable=protected-access
-        self.openshift.wait_for_ready(self.deployment)
+        self.deployment.wait_for()
 
     def destroy(self):
         if self.apicast:

--- a/testsuite/gateways/service_mesh/mesh.py
+++ b/testsuite/gateways/service_mesh/mesh.py
@@ -79,4 +79,4 @@ class ServiceMesh:
     @property
     def environ(self) -> Properties:
         """Returns Environ object for manipulation of the adapter environment"""
-        return self.openshift.deployment_environ("3scale-istio-adapter")
+        return self.openshift.environ("deployment/3scale-istio-adapter")

--- a/testsuite/openshift/deployments.py
+++ b/testsuite/openshift/deployments.py
@@ -1,0 +1,217 @@
+"""Module containing Deployment related classes"""
+import os
+import typing
+from abc import ABC, abstractmethod
+from contextlib import ExitStack
+from datetime import timezone
+
+import openshift as oc
+from testsuite.openshift.env import Environ
+
+if typing.TYPE_CHECKING:
+    from testsuite.openshift.client import OpenShiftClient
+
+
+class Deployment(ABC):
+    """Common class for KubernetesDeployments and DeploymentConfigs,
+     enables functionality that works on both to be written once"""
+    def __init__(self, openshift: "OpenShiftClient", resource) -> None:
+        super().__init__()
+        self.openshift = openshift
+        self.resource = resource
+        split = resource.split("/")
+        self.resource_type = split[0]
+        self.name = split[1]
+
+    def scale(self, replicas: int):
+        """
+        Scale an existing version of Deployment.
+        Args:
+            :param replicas: scale up/down to this number
+        """
+        self.openshift.do_action("scale", ["--replicas", str(replicas), self.resource])
+        if replicas > 0:
+            self.wait_for(self.resource)
+
+    def environ(self) -> Environ:
+        """Dict-like access to environment variables"""
+        return Environ(self)
+
+    def rsync(self, source: str, dest: str):
+        """Copy files from remote pod container to local.
+
+        First container in the pod from the specified deployment will be used.
+
+        Note: For the time being, rsync is only available from remote to local.
+
+        Args:
+            :param source: Remote file-path.
+            :param dest: Local dir where the file will be copied to.
+        """
+        if not os.path.isdir(dest):
+            raise ValueError("You must provide a valid local directory to 'dest'.")
+
+        pod = self.get_pods().object().name()
+        self.openshift.do_action("rsync", [f"{pod}:{source}", dest])
+
+    def get_replicas(self):
+        """
+        Return number of replicas of Deployment
+        """
+        with ExitStack() as stack:
+            self.openshift.prepare_context(stack)
+            selector = oc.selector(self.resource)
+            deployment = selector.objects()[0]
+            return deployment.model.spec.replicas
+
+    # pylint: disable=too-many-arguments
+    def add_volume(self, volume_name: str, mount_path: str,
+                   secret_name: str = None, configmap_name: str = None):
+        """Add volume to a given deployment.
+
+        Args:
+            :param volume_name: The volume name
+            :param mount_path: The path to be mounted
+            :param secret_name: The name of an existing Secret
+            :param configmap_name: The name of an existing ConfigMap
+        """
+        self._manage_volume("add", volume_name, mount_path, secret_name, configmap_name)
+
+    def remove_volume(self, volume_name: str):
+        """Remove volume from a given deployment.
+
+        Args:
+            :param volume_name: The volume name
+        """
+        self._manage_volume("remove", volume_name)
+
+    # pylint: disable=too-many-arguments
+    def _manage_volume(self, action: str, volume_name: str,
+                       mount_path: str = None, secret_name: str = None,
+                       configmap_name: str = None):
+        """Manage volumes for a given deployment.
+
+        You can add or remove a volume by passing `add` or `remove` to :param action.
+
+        Args:
+            :param action: Either "add" or "remove" option
+            :param volume_name: The volume name
+            :param mount_path: The path to be mounted
+            :param secret_name: The name of an existing Secret
+            :param configmap_name: The name of an existing ConfigMap
+        """
+        if secret_name and configmap_name:
+            raise ValueError("You must use either Secret or ConfigMap, not both.")
+
+        opt_args = ["--name", volume_name]
+        if mount_path:
+            opt_args.extend(["--mount-path", mount_path])
+
+        if secret_name:
+            opt_args.extend(["--secret-name", secret_name])
+
+        if configmap_name:
+            opt_args.extend(["--configmap-name", configmap_name])
+
+        self.openshift.do_action("set", ["volume", self.resource, f"--{action}", opt_args])
+        self.wait_for()
+
+    def get_logs(self, since_time=None, tail: int = -1) -> str:
+        """
+        Get merged logs for the pods of the most recent deployment
+
+        :param since_time starting time from logs
+        :param tail: how many logs to get, defaults to all
+        :return: logs of the pod
+        """
+        cmd_args = []
+        if since_time is not None:
+            d_with_timezone = since_time.replace(tzinfo=timezone.utc)
+            time = d_with_timezone.isoformat()
+            cmd_args.append(f"--since-time={time}")
+        pod = self.get_pods()
+        logs = pod.logs(tail, cmd_args=cmd_args)
+        return "".join(logs.values())
+
+    def patch(self, patch, patch_type: str = None, timeout=90):
+        """Patches the deployment and waits until it is applied"""
+        self.openshift.patch(self.resource_type, self.name, patch, patch_type)
+        self.wait_for(timeout)
+
+    def delete(self):
+        """Deletes deployment"""
+        self.openshift.delete(self.resource_type, self.name)
+
+    def __str__(self) -> str:
+        return self.resource
+
+    @abstractmethod
+    def rollout(self):
+        """Rollouts (=redeploys) new configuration"""
+
+    @abstractmethod
+    def wait_for(self, timeout: int = 90):
+        """Waits until all the replicas are ready"""
+
+    @abstractmethod
+    def get_pods(self):
+        """Returns Selector for all pods for Deployment"""
+
+
+class KubernetesDeployment(Deployment):
+    """Pure Kubernetes deployment"""
+    def __init__(self, openshift: "OpenShiftClient", resource: "str") -> None:
+        super().__init__(openshift, resource)
+
+    def rollout(self):
+        self.openshift.do_action("delete", ["pod", "--force",
+                                            "--grace-period=0", "-l", f"deployment={self.name}"])
+        self.wait_for()
+
+    def wait_for(self, timeout: int = 90):
+        with ExitStack() as stack:
+            self.openshift.prepare_context(stack)
+            stack.enter_context(oc.timeout(timeout))
+            oc.selector(self.resource).until_all(
+                success_func=lambda deployment: "readyReplicas" in deployment.model.status
+            )
+
+    def get_pods(self):
+        """Kubernetes Deployment doesnt have a nice universal way how to get the correct pods,
+        so this method relies on pods having the deployment label"""
+        return self.openshift.select_resource("pods", labels={"deployment": self.name})
+
+
+class DeploymentConfig(Deployment):
+    """OpenShift DeploymentConfig object"""
+    def __init__(self, openshift: "OpenShiftClient", resource: str) -> None:
+        super().__init__(openshift, resource)
+
+    def rollout(self):
+        self.openshift.do_action("rollout", ["latest", self.resource])
+        self.openshift.do_action("rollout", ["status", self.resource])
+
+    def wait_for(self, timeout: int = 90):
+        with ExitStack() as stack:
+            self.openshift.prepare_context(stack)
+            stack.enter_context(oc.timeout(timeout))
+
+            dc_data = oc.selector(self.resource).object()
+            dc_version = dc_data.model.status.latestVersion
+            oc.selector(
+                "pods",
+                labels={
+                    "deployment": f"{self.name}-{dc_version}"
+                }
+            ).until_all(
+                success_func=lambda pod: (
+                    pod.model.status.phase == "Running" and pod.model.status.containerStatuses[0].ready
+                )
+            )
+
+    def get_pods(self):
+        def select_pod(apiobject):
+            latest_version = apiobject.get_annotation("openshift.io/deployment-config.latest-version")
+            return apiobject.get_label("deployment") == f"{self.name}-{latest_version}"
+
+        return self.openshift.select_resource("pods", narrow_function=select_pod)

--- a/testsuite/openshift/scaler.py
+++ b/testsuite/openshift/scaler.py
@@ -2,6 +2,8 @@
 import typing
 from contextlib import contextmanager
 
+from testsuite.openshift.deployments import DeploymentConfig
+
 if typing.TYPE_CHECKING:
     from testsuite.openshift.client import OpenShiftClient
     from testsuite.openshift.crd.apimanager import APIManager
@@ -33,8 +35,9 @@ class Scaler:
         if self.operator_deploy:
             apimanager_func = getattr(self.apimanager, self.DEPLOYMENT_MAPPINGS[deployment_name])
             return apimanager_func(replicas, wait_for_replicas=wait_for_replicas)
-        previous_replicas = self.client.get_replicas(deployment_name)
-        self.client.scale(deployment_name, replicas)
+        deployment = DeploymentConfig(self.client, f"dc/{deployment_name}")
+        previous_replicas = deployment.get_replicas()
+        deployment.scale(replicas)
         return previous_replicas
 
     @contextmanager

--- a/testsuite/tests/apicast/parameters/test_apicast_access_log_file.py
+++ b/testsuite/tests/apicast/parameters/test_apicast_access_log_file.py
@@ -54,7 +54,7 @@ def read_log(staging_gateway, tmpdir):
         dest = f"{tmpdir}/{filename}"
 
         # copy log file from apicast to local
-        staging_gateway.openshift.rsync(staging_gateway.deployment, source, tmpdir)
+        staging_gateway.deployment.rsync(source, tmpdir)
 
         with open(dest, encoding="utf8") as file:
             content = file.read()

--- a/testsuite/tests/apicast/parameters/test_threescale_config_file.py
+++ b/testsuite/tests/apicast/parameters/test_threescale_config_file.py
@@ -44,8 +44,7 @@ def get_apicast_config(service):
 def setup_apicast_configuration(service, staging_gateway, configmap_name):
     """Configure apicast for reading configuration from ConfigMap."""
     staging_gateway.openshift.config_maps.add(configmap_name, get_apicast_config(service))
-    staging_gateway.openshift.add_volume(staging_gateway.deployment, "apicast-config-vol",
-                                         "/opt/config", configmap_name=configmap_name)
+    staging_gateway.deployment.add_volume("apicast-config-vol", "/opt/config", configmap_name=configmap_name)
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/policy/tls/conftest.py
+++ b/testsuite/tests/apicast/policy/tls/conftest.py
@@ -131,8 +131,7 @@ def mount_certificate_secret(request, staging_gateway):
         request.addfinalizer(turn_down)
 
         staging_gateway.openshift.secrets.create(secret_name, SecretKinds.TLS, certificate=certificate)
-        staging_gateway.openshift.add_volume(staging_gateway.deployment, secret_name,
-                                             mount_path, secret_name)
+        staging_gateway.deployment.add_volume(secret_name, mount_path, secret_name)
 
     return _mount
 

--- a/testsuite/tests/apicast/policy/tls/tls_upstream/conftest.py
+++ b/testsuite/tests/apicast/policy/tls/tls_upstream/conftest.py
@@ -89,10 +89,9 @@ def custom_httpbin(staging_gateway, request, upstream_certificate, upstream_auth
 
         request.addfinalizer(
             lambda: staging_gateway.openshift.delete_template(path, parameters))
-
         staging_gateway.openshift.new_app(path, parameters)
         # pylint: disable=protected-access
-        staging_gateway.openshift._wait_for_deployment(name)
+        staging_gateway.openshift.deployment(f"dc/{name}").wait_for()
 
         if tls_route_type is not None:
             request.addfinalizer(lambda: openshift.delete("route", name))

--- a/testsuite/tests/prometheus/apicast/test_metric_worker_starts.py
+++ b/testsuite/tests/prometheus/apicast/test_metric_worker_starts.py
@@ -27,7 +27,7 @@ def test_metric_worker(prometheus, production_gateway):
                    'if [[ $? == 0 ]]; then echo ${k##*/}; fi;'
                    'done | xargs kill -9')
     ocp = production_gateway.openshift
-    pod = ocp.get_pod(production_gateway.deployment)
+    pod = production_gateway.deployment.get_pods()
     ocp.do_action("exec", ['-ti', pod.names()[0], "--", "/bin/sh", "-c", kill_worker])
 
     # prometheus is downloading metrics periodicity, we need to wait for next fetch

--- a/testsuite/tests/prometheus/zync/test_annotations.py
+++ b/testsuite/tests/prometheus/zync/test_annotations.py
@@ -18,10 +18,10 @@ ANNOTATIONS = [
 ]
 
 
-@pytest.fixture(params=['zync', 'zync-que'])
+@pytest.fixture(params=['dc/zync', 'dc/zync-que'])
 def poda(request):
     """Return zync pod object."""
-    pod = openshift().get_pod(request.param).object()
+    pod = openshift().deployment(request.param).get_pods().object()
     return pod
 
 


### PR DESCRIPTION
# Why?
* Currently `OpenShiftClient` is a big mess, if we want the same thing to works on both Deployment and DeploymentConfig we need one method for each of them
   *  For example,`_wait_for_deployment` and `wait_for_ready` - Both wait until the resource is ready, but one is for `DeploymentConfig` and one for `Deployment` (You can try to guess which one)
* Most of the methods are written to work only on `DeploymentConfig` even though they could easily work on `Deployment` too 

# Overview
* Adds Deployments class  
   * Enables all methods that worked on `DeploymentConfig` to also work on Kubernetes `Deployment`
   * Requires only a few methods to be overridden by `KubernetesDeployments` and `DeploymentConfigs` classes to work
* Change is not transparent
   * One of the problems I am trying to solve is that the naming is confusing and most methods aren't used more than once.
      * Only exception being `environ()` method, which is used extensively and which has transparency method.
      * However, if wanted, more of the methods could be made transparent with the default resource type being `DeploymentConfig`. I do not think that it is justified for most of them.
* This is a refactor MR, meaning I did not change functionality in any way.

# TODO
* Test that nothing broke