### PR TITLE
Assert success not result.err()

### DIFF
--- a/testsuite/gateways/apicast/operator.py
+++ b/testsuite/gateways/apicast/operator.py
@@ -67,8 +67,7 @@ class OperatorEnviron(Properties):
         def _update(apicast):
             for name, value in envs.items():
                 self._set(apicast, name, value)
-        result, _ = self.apicast.modify_and_apply(_update)
-        assert not result.err(), result.err()
+        self.apicast.modify_and_apply(_update)
         self.wait_function()
 
     def __getitem__(self, name):
@@ -80,8 +79,7 @@ class OperatorEnviron(Properties):
         raise NotImplementedError(f"Env variable {name} doesn't exists or is not yet implemented in operator")
 
     def __setitem__(self, name, value):
-        result, _ = self.apicast.modify_and_apply(lambda apicast: self._set(apicast, name, value))
-        assert not result.err(), result.err()
+        self.apicast.modify_and_apply(lambda apicast: self._set(apicast, name, value))
         self.wait_function()
 
     def __delitem__(self, name):

--- a/testsuite/openshift/crd/apicast.py
+++ b/testsuite/openshift/crd/apicast.py
@@ -56,6 +56,15 @@ class APIcast(APIObject):
         self.create(["--save-config=true"])
         return self.refresh()
 
+    # pylint: disable=arguments-differ
+    # I am only adding optional argument, so it shouldn't be a big problem
+    def modify_and_apply(self, modifier_func, retries=2, cmd_args=None, ignore_errors=False):
+        """Modified version which asserts that it succeeds"""
+        result, success = super().modify_and_apply(modifier_func, retries, cmd_args)
+        if not ignore_errors:
+            assert success, result.err()
+        return result, success
+
     # Direct access to spec attributes, since all of the attributes are located directly there
     def __getitem__(self, item):
         return self.model.spec.get(item, default=None)


### PR DESCRIPTION
- In some instances result.err() is not empty but at the same time it did succeed, this should work more reliably.
- Move asserts into APIcast CR Object