### PR TITLE
Make SelfManagedApicast more flexible

### DIFF
--- a/doc/GATEWAYS.md
+++ b/doc/GATEWAYS.md
@@ -67,6 +67,20 @@ gateway:
    path_routing: false                   # Optional: True, if the path_routing should be used
    kind: "TemplateApicast"
 ```
+## SelfManaged APIcast
+*Description*: Dynamically select appropriate APIcast deployment method.
+Used basically to get available and best fit deployment. Chosen deployment type
+is one of its subclasses (at the time of writing this text it was
+TemplateApicast or OperatorApicast). The exact deployment can be forced in
+configuration. The arguments for final instance are read from particular
+subsection in config (default or ClassName).
+```
+gateway:
+  default:
+    kind: SelfManagedApicast
+  SelfManagedApicast:
+    force: OperatorApicast
+```
 ## TLS APIcast
 *Description*: Extension to Template APIcast, which sets up APIcast for TLS communication
 

--- a/testsuite/configuration.py
+++ b/testsuite/configuration.py
@@ -25,9 +25,10 @@ def openshift(server="default", project="threescale") -> OpenShiftClient:
 
 def call(method, **kwargs):
     """Calls method with only parameters it requires"""
-    # Due to SelfManaged overriding __new__, inspect cannot infer the expected variables from __new__
-    inspected_method = method.__init__ if inspect.isclass(method) else method
-    expected = inspect.signature(inspected_method).parameters.keys()
+    if hasattr(method, "expected_init_args"):
+        expected = method.expected_init_args()
+    else:
+        expected = inspect.signature(method.__init__).parameters.keys()
     return method(**{k: v for k, v in kwargs.items() if k in expected})
 
 

--- a/testsuite/gateways/__init__.py
+++ b/testsuite/gateways/__init__.py
@@ -4,16 +4,13 @@ Sets up gateway defined in testsuite settings
 import importlib
 import inspect
 import pkgutil
-from typing import Type, TypeVar, Union
+from typing import Type, Union
 
 from testsuite.config import settings
-from testsuite.configuration import SettingsParser
-from testsuite.gateways.gateways import AbstractGateway
+from testsuite.gateways.gateways import AbstractGateway, Gateway, new_gateway
 
 # walk through all sub-packages and import all gateway classes
-__all__ = ["gateway", "default"]
-
-Gateway = TypeVar("Gateway", bound=AbstractGateway)
+__all__ = ["gateway", "default", "Gateway"]
 
 for _, module, _ in pkgutil.walk_packages(__path__, "testsuite.gateways."):  # type: ignore
     imported = importlib.import_module(module)
@@ -24,19 +21,13 @@ for _, module, _ in pkgutil.walk_packages(__path__, "testsuite.gateways."):  # t
                 globals()[item] = obj
                 __all__.append(item)
 
-
-def load_type():
-    """Loads currently selected global gateway"""
-    return globals()[settings["threescale"]["gateway"]["default"]["kind"]]
-
-
 # Best name would be type, but that is a function. I also oppose clazz
-default = load_type()
+default = globals()[settings["threescale"]["gateway"]["default"]["kind"]]
 
 
 # This could be written much more cleanly without specifying kind,
 # but this version enables typing support if kind is a class
-def gateway(kind: Union[Type[Gateway], str] = None, staging: bool = True, **kwargs) -> Gateway:
+def gateway(kind: Union[Type[Gateway], str] = default, staging: bool = True, **kwargs) -> Gateway:
     """
     Return gateway instance of given kind
     Settings priority:
@@ -44,19 +35,4 @@ def gateway(kind: Union[Type[Gateway], str] = None, staging: bool = True, **kwar
     2. Settings block named after the class name (TemplateApicast)
     3. default settings block
     """
-    configuration = settings["threescale"]["gateway"]["default"].copy()
-    kind = kind or configuration["kind"]
-    clazz = globals()[kind] if not inspect.isclass(kind) else kind  # type: ignore
-    if hasattr(clazz, "resolve_class"):
-        clazz = clazz.resolve_class()
-
-    name = clazz.__name__
-    named_settings = {}
-    if name in settings["threescale"]["gateway"]:
-        named_settings = settings["threescale"]["gateway"][name]
-
-    configuration.update(named_settings)
-    configuration.update(kwargs)
-    configuration["kind"] = clazz
-
-    return SettingsParser().process(global_kwargs={"staging": staging}, **configuration)
+    return new_gateway(globals(), settings["threescale"]["gateway"], kind, staging, **kwargs)

--- a/testsuite/gateways/apicast/__init__.py
+++ b/testsuite/gateways/apicast/__init__.py
@@ -1,10 +1,20 @@
 """Module containing all APIcast gateways"""
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Optional
+from typing import Optional, List, Dict
+import logging
+
+from threescale_api.resources import Service
 
 from testsuite.capabilities import Capability
 from testsuite.gateways import AbstractGateway
+from testsuite import utils
+from testsuite.openshift.client import OpenShiftClient
+from testsuite.openshift.deployments import Deployment
+from testsuite.openshift.env import Properties
+from testsuite.openshift.objects import Routes
+
+LOGGER = logging.getLogger(__name__)
 
 
 class AbstractApicast(AbstractGateway, ABC):
@@ -25,3 +35,129 @@ class AbstractApicast(AbstractGateway, ABC):
 
     def destroy(self):
         pass
+
+
+class OpenshiftApicast(AbstractApicast, ABC):
+    """Super-class for selfmanaged apicast deployed to openshift"""
+
+    CAPABILITIES = {Capability.APICAST,
+                    Capability.CUSTOM_ENVIRONMENT,
+                    Capability.PRODUCTION_GATEWAY,
+                    Capability.LOGS,
+                    Capability.JAEGER}
+    HAS_PRODUCTION = True
+    PRIORITY = 100
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+            self, staging: bool, openshift: OpenShiftClient, name, generate_name=False, path_routing=False):
+        self.staging = staging
+        self.secure = True
+        self.path_routing = path_routing
+
+        self.openshift = openshift
+        self.name = name
+        if generate_name:
+            name = f"{name}-stage" if staging else name
+            self.name = f"{name}-{utils.randomize(utils._whoami()[:8])}"
+        self._routes: List[str] = []
+        self._base_route = None
+
+    @staticmethod
+    def fits(openshift: OpenShiftClient):  # pylint: disable=unused-argument
+        """
+        True, if this instance fits the current environment
+        Every subclass should override it
+        """
+        return False
+
+    @property
+    def deployment(self) -> Deployment:
+        """Gateway deployment"""
+        return self.openshift.deployment(f"dc/{self.name}")
+
+    def _routename(self, service):
+        """name of route for given service"""
+        route = f"{service.entity_id}"
+        if self.staging:
+            route = f"{route}-stage"
+        return route
+
+    @property
+    def base_route(self):
+        """Route that points at the APIcast itself"""
+        if self._base_route is None:
+            hostname = self.get_route(f"base-{self.deployment.name}")
+            self._base_route = hostname
+        return self._base_route
+
+    def destroy(self):
+        super().destroy()
+
+        for route in self._routes:
+            if route in self.openshift.routes:
+                LOGGER.debug('Removing route "%s"...', route)
+                del self.openshift.routes[route]
+
+    def create(self):
+        super().create()
+
+        if self.path_routing:
+            self.add_route(f"base-{self.deployment.name}")
+
+    def before_service(self, service_params: Dict) -> Dict:
+        service_params.update({"deployment_option": "self_managed"})
+        return service_params
+
+    def before_proxy(self, service: Service, proxy_params: Dict) -> Dict:
+        if self.path_routing:
+            host = self.base_route
+        else:
+            route = self.add_route(self._routename(service))
+            host = route.model.spec.host
+
+        key = "sandbox_endpoint" if self.staging else "endpoint"
+        url = f"https://{host}" if self.secure else f"http://{host}"
+        proxy_params.update({key: url})
+        return proxy_params
+
+    def on_service_delete(self, service: Service):
+        super().on_service_delete(service)
+        if not self.path_routing:
+            self.delete_route(self._routename(service))
+
+    def add_route(self, name, kind=Routes.Types.EDGE):
+        """Adds new route for this APIcast"""
+        result = self.openshift.routes.create(name, kind, service=self.deployment.name, **{"insecure-policy": "Allow"})
+        self._routes.append(name)
+        return result
+
+    def get_route(self, name):
+        """Return route host with specified name"""
+        return self.openshift.do_action("get", ["route", name, "-o", "jsonpath={$..spec..host}"]).out().strip()
+
+    def delete_route(self, name):
+        """Delete route"""
+        if name in self._routes and name in self.openshift.routes:
+            del self.openshift.routes[name]
+            self._routes.remove(name)
+
+    @property
+    def environ(self) -> Properties:
+        return self.deployment.environ()
+
+    def reload(self):
+        self.deployment.rollout()
+
+    def get_logs(self, since_time=None):
+        return self.deployment.get_logs(since_time=since_time)
+
+    def set_image(self, image):
+        """Sets specific image to the deployment config and redeploys it"""
+        self.deployment.patch([
+                {
+                    "op": "replace",
+                    "path": "/spec/template/spec/containers/0/image",
+                    "value": image
+                }
+            ], patch_type="json")

--- a/testsuite/gateways/apicast/selfmanaged.py
+++ b/testsuite/gateways/apicast/selfmanaged.py
@@ -1,16 +1,12 @@
 """Self-managed APIcast already deployed somewhere in OpenShift """
+import inspect
 import logging
-from typing import Dict, List
+from typing import Union, Type
 
-from threescale_api.resources import Service
-
-from testsuite import utils
 from testsuite.capabilities import Capability
-from testsuite.gateways.apicast import AbstractApicast
+from testsuite.gateways.gateways import Gateway, new_gateway
+from testsuite.gateways.apicast import AbstractApicast, OpenshiftApicast
 from testsuite.openshift.client import OpenShiftClient
-from testsuite.openshift.deployments import Deployment
-from testsuite.openshift.env import Properties
-from testsuite.openshift.objects import Routes
 
 LOGGER = logging.getLogger(__name__)
 
@@ -19,8 +15,16 @@ class NoSuitableApicastError(Exception):
     """Raised if no deployment method is found"""
 
 
+# pylint: disable=too-many-instance-attributes
 class SelfManagedApicast(AbstractApicast):
-    """Gateway for use with already deployed self-managed APIcast in OpenShift"""
+    """Gateway for use with already deployed self-managed APIcast in OpenShift
+
+    This is a "special" class behaving bit more dynamically during
+    instantiation. Actually it can return instance of different class (never
+    returns self in fact). It returns instance of OpenshiftApicast subclass
+    that fits to the definition and/or environment. Due to this behavior
+    specific criteria have to be met.
+    """
 
     CAPABILITIES = {Capability.APICAST,
                     Capability.CUSTOM_ENVIRONMENT,
@@ -30,131 +34,39 @@ class SelfManagedApicast(AbstractApicast):
     HAS_PRODUCTION = True
 
     # pylint: disable=unused-argument
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, staging: bool, openshift: OpenShiftClient, settings,
+                force: Union[Type[Gateway], str] = None, **kwargs):
+        """
+        :param force: The class to use can be defined explicitly
+        """
         if cls is SelfManagedApicast:
-            klass = cls.resolve_class()
-            super().__new__(klass)
+            kind = force
+            subclasses = OpenshiftApicast.__subclasses__()
+            if isinstance(kind, str):
+                for subclass in subclasses:
+                    if subclass.__name__ == kind:
+                        kind = subclass  # type: ignore
+                        break
+            if not kind:
+                candidates = sorted([i for i in subclasses if i.fits(openshift)], key=lambda x: x.PRIORITY)
+                if len(candidates):
+                    kind = candidates[-1]  # type: ignore
+            if kind:
+                LOGGER.debug("Chosen: %s", kind)
+                classes = {i.__name__: i for i in subclasses}
+                return new_gateway(classes, settings, kind, staging, **kwargs)
+            raise NoSuitableApicastError()
         return super().__new__(cls)
 
-    # pylint: disable=too-many-arguments
-    def __init__(self, staging: bool, openshift: OpenShiftClient, name, generate_name=False, path_routing=False):
-        self.staging = staging
-        self.secure = True
-        self.path_routing = path_routing
-
-        self.openshift = openshift
-        self.name = name
-        if generate_name:
-            name = f"{name}-stage" if staging else name
-            self.name = f"{name}-{utils.randomize(utils._whoami()[:8])}"
-        self._routes: List[str] = []
-        self._base_route = None
+    # pylint: disable=unused-argument
+    def __init__(self, staging: bool, openshift: OpenShiftClient, settings,
+                 force: Union[Type[Gateway], str] = None, **kwargs):
+        raise TypeError("SelfManagedApicast should be never created actually")
 
     @classmethod
-    def resolve_class(cls):
-        """Returns actual class that will be instantiated"""
-        if cls is SelfManagedApicast:
-            for klass in cls.__subclasses__():
-                if klass.fits():
-                    return klass
-            raise NoSuitableApicastError()
-        return cls
-
-    @staticmethod
-    def fits():   # pylint: disable=unused-argument
-        """
-        True, if this instance fits the current environment
-        Every subclass should override it
-        """
-        return False
-
-    @property
-    def deployment(self) -> Deployment:
-        """Gateway deployment"""
-        return self.openshift.deployment(f"dc/{self.name}")
-
-    def _routename(self, service):
-        """name of route for given service"""
-        route = f"{service.entity_id}"
-        if self.staging:
-            route = f"{route}-stage"
-        return route
-
-    @property
-    def base_route(self):
-        """Route that points at the APIcast itself"""
-        if self._base_route is None:
-            hostname = self.get_route(f"base-{self.deployment.name}")
-            self._base_route = hostname
-        return self._base_route
-
-    def destroy(self):
-        super().destroy()
-
-        for route in self._routes:
-            if route in self.openshift.routes:
-                LOGGER.debug('Removing route "%s"...', route)
-                del self.openshift.routes[route]
-
-    def create(self):
-        super().create()
-
-        if self.path_routing:
-            self.add_route(f"base-{self.deployment.name}")
-
-    def before_service(self, service_params: Dict) -> Dict:
-        service_params.update({"deployment_option": "self_managed"})
-        return service_params
-
-    def before_proxy(self, service: Service, proxy_params: Dict) -> Dict:
-        if self.path_routing:
-            host = self.base_route
-        else:
-            route = self.add_route(self._routename(service))
-            host = route.model.spec.host
-
-        key = "sandbox_endpoint" if self.staging else "endpoint"
-        url = f"https://{host}" if self.secure else f"http://{host}"
-        proxy_params.update({key: url})
-        return proxy_params
-
-    def on_service_delete(self, service: Service):
-        super().on_service_delete(service)
-        if not self.path_routing:
-            self.delete_route(self._routename(service))
-
-    def add_route(self, name, kind=Routes.Types.EDGE):
-        """Adds new route for this APIcast"""
-        result = self.openshift.routes.create(name, kind, service=self.deployment.name, **{"insecure-policy": "Allow"})
-        self._routes.append(name)
-        return result
-
-    def get_route(self, name):
-        """Return route host with specified name"""
-        return self.openshift.do_action("get", ["route", name, "-o", "jsonpath={$..spec..host}"]).out().strip()
-
-    def delete_route(self, name):
-        """Delete route"""
-        if name in self._routes and name in self.openshift.routes:
-            del self.openshift.routes[name]
-            self._routes.remove(name)
-
-    @property
-    def environ(self) -> Properties:
-        return self.deployment.environ()
-
-    def reload(self):
-        self.deployment.rollout()
-
-    def get_logs(self, since_time=None):
-        return self.deployment.get_logs(since_time=since_time)
-
-    def set_image(self, image):
-        """Sets specific image to the deployment config and redeploys it"""
-        self.deployment.patch([
-                {
-                    "op": "replace",
-                    "path": "/spec/template/spec/containers/0/image",
-                    "value": image
-                }
-            ], patch_type="json")
+    def expected_init_args(cls):
+        """Collect all the init parameters from cls and its subclasses"""
+        expected = set(inspect.signature(cls.__new__).parameters.keys())
+        for subclass in OpenshiftApicast.__subclasses__():
+            expected.update(inspect.signature(subclass.__init__).parameters.keys())
+        return list(expected - {'self', 'kwargs'})

--- a/testsuite/gateways/apicast/template.py
+++ b/testsuite/gateways/apicast/template.py
@@ -6,13 +6,12 @@ import importlib_resources as resources
 
 from testsuite.openshift.objects import SecretTypes
 from testsuite.openshift.client import OpenShiftClient
-from .selfmanaged import SelfManagedApicast
-from ...capabilities import CapabilityRegistry, Capability
+from . import OpenshiftApicast
 
 LOGGER = logging.getLogger(__name__)
 
 
-class TemplateApicast(SelfManagedApicast):
+class TemplateApicast(OpenshiftApicast):
     """Template-based APIcast Gateway."""
 
     # pylint: disable=too-many-arguments
@@ -37,8 +36,8 @@ class TemplateApicast(SelfManagedApicast):
                 "CONFIGURATION_CACHE": 0})
 
     @staticmethod
-    def fits():
-        return Capability.OCP3 in CapabilityRegistry()
+    def fits(openshift: OpenShiftClient):  # pylint: disable=unused-argument
+        return True
 
     def _create_configuration_url_secret(self):
         self.openshift.secrets.create(

--- a/testsuite/gateways/gateways.py
+++ b/testsuite/gateways/gateways.py
@@ -1,8 +1,9 @@
 """Module containing all basic gateways"""
 from abc import ABC, abstractmethod
-from typing import Set
+from typing import Set, Type, TypeVar, Union
 
 from testsuite.capabilities import Capability
+from testsuite.configuration import SettingsParser
 from testsuite.lifecycle_hook import LifecycleHook
 from testsuite.openshift.env import Properties
 
@@ -25,3 +26,29 @@ class AbstractGateway(LifecycleHook, ABC):
     @abstractmethod
     def destroy(self):
         """Destroys gateway"""
+
+
+Gateway = TypeVar("Gateway", bound=AbstractGateway)
+
+
+def new_gateway(
+        kinds: dict, settings_, kind: Union[Type[Gateway], str] = None, staging: bool = True, **kwargs) -> Gateway:
+    """Low-level function to initialize gateway of given type. Not to be used directly.
+
+    Settings priority:
+    1. Function arguments
+    2. Settings block named after the class name (TemplateApicast)
+    3. default settings block
+    """
+    configuration = settings_["default"].copy()
+    clazz = kinds[kind] if isinstance(kind, str) else kind  # type: ignore
+    if clazz is None:
+        clazz = kinds[settings_["default"]["kind"]]
+
+    if clazz.__name__ in settings_:
+        configuration.update(settings_[clazz.__name__])
+    configuration.update(kwargs)
+    configuration["kind"] = clazz
+    configuration["settings"] = settings_
+
+    return SettingsParser().process(global_kwargs={"staging": staging}, **configuration)

--- a/testsuite/openshift/client.py
+++ b/testsuite/openshift/client.py
@@ -62,6 +62,15 @@ class OpenShiftClient:
             return result
 
     @property
+    def project_exists(self):
+        """Returns True if the project exists"""
+        try:
+            self.do_action("get", f"project/{self.project_name}")
+            return True
+        except oc.OpenShiftPythonException:
+            return False
+
+    @property
     def is_operator_deployment(self):
         """
         True, if the said namespace contains at least one APIManager resource


### PR DESCRIPTION
Primary idea behind this change is:
 - get ability to set instance of SelfManagedApicast explicitly
   (force option)

Secondary benefit is:
 - (CHANGE IN BEHAVIOR!) more dynamic selection
   (fallback to TemplateApicast actually as this is "always" available)