### PR TITLE
Leverage WORKSPACE env if set (ran in jenkins)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,12 @@
 
 TB ?= short
 LOGLEVEL ?= INFO
+
+ifdef WORKSPACE  # Yes, this is for jenkins
+resultsdir ?= $(WORKSPACE)
+else
 resultsdir ?= .
+endif
 
 PIPENV_VERBOSITY ?= -1
 PIPENV_IGNORE_VIRTUALENVS ?= 1


### PR DESCRIPTION
If $WORKSPACE is defined then it will be used as resultdir