### PR TITLE
toolbox: add AutoAdd policy to paramiko

### DIFF
--- a/testsuite/toolbox/toolbox.py
+++ b/testsuite/toolbox/toolbox.py
@@ -37,6 +37,7 @@ def ssh_client():
     @return ssh client
     """
     client = paramiko.client.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy)
     client.load_system_host_keys()
     client.connect(settings['toolbox']['machine_ip'],
                    username=settings['toolbox']['ssh_user'],


### PR DESCRIPTION
This change is needed so toolbox tests executed from container would no longer
require known_hosts file (with fingerprint of toolbox.machine_ip) to be
present.