### PR TITLE
Fix ApplicationCreateView create button

### DIFF
--- a/testsuite/ui/views/admin/audience/application.py
+++ b/testsuite/ui/views/admin/audience/application.py
@@ -96,7 +96,7 @@ class ApplicationNewView(BaseAudienceView):
     app_plan = ThreescaleSelect(locator="//label[@for='cinstance_plan_id']/../div[1]")
     product = ThreescaleSelect(locator="//label[@for='product']/../div[1]")
     service_plan = ThreescaleSelect(locator="//label[@for='cinstance_service_plan_id']/../div[1]")
-    create_button = ThreescaleCreateButton()
+    create_button = ThreescaleCreateButton(locator="//button[contains(text(), 'Create')]")
 
     def __init__(self, parent, account):
         super().__init__(parent, account_id=account.entity_id)


### PR DESCRIPTION
In alpha, they changed the header so that the current locator in `ThreescaleCreateButton` will match both h2 and the button and decide to click on h2. This hotfix makes it that it selects only the actual button.