### PR TITLE
Looong wait time on custom tenant

### DIFF
--- a/testsuite/tests/custom_tenant/test_custom_tenant.py
+++ b/testsuite/tests/custom_tenant/test_custom_tenant.py
@@ -12,7 +12,10 @@ def threescale(custom_tenant, testconfig):
     the new tenant
     """
     tenant = custom_tenant()
-    return tenant.admin_api(ssl_verify=testconfig["ssl_verify"], wait=32)
+    # This has to wait, backoff is not an option as this can create an object
+    # despite to returned error (would keep trash there), the wait time has to
+    # be really long.
+    return tenant.admin_api(ssl_verify=testconfig["ssl_verify"], wait=3*60)
 
 
 # FIXME: threescale_api.errors.ApiClientError: Response(422): b'{"errors":{"system_name":["must be shorter."]}}


### PR DESCRIPTION
Recent testruns revealed that waiting 2.5 minutes doesn't have to be
enough.