### PR TITLE
Run make tests by files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ all-is-package:
 
 test: ## Run test
 test pytest tests: pipenv
-	$(PYTEST) -n4 -m 'not flaky' $(flags) testsuite
+	$(PYTEST) -n4 -m 'not flaky' --dist loadfile $(flags) testsuite
 
 speedrun: ## Bigger than smoke faster than test
 speedrun: pipenv


### PR DESCRIPTION
# Why
Problem with xdist I encounter is that with the default load balancer multiple tests in one file can be assigned to many processes which causes duplicate gateway (among others) initialization when it is not needed. This means that in many cases gateways are created much more often than they need to be causing unneeded load for cluster and 3scale (more unneeded service), increasing test times and chance for a random failure. This problem is only for tests that have expensive setups and there are more than one test case in the file.

# Solution
This setting simply groups tests by file before assigning them to processes which make removed this problem.

# TODO
* Test that nothing broke