### PR TITLE
Release on GitHub

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -1,0 +1,18 @@
+name: create release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: string
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          make clean release
+          git push -u origin HEAD
+          gh pr create --fill --reviewer mganisin,pehala
+        env:
+          VERSION: ${{ github.event.inputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -116,14 +116,15 @@ testsuite/resources/apicast.yml: FORCE VERSION-required
 	curl -f https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/master/apicast-gateway/apicast.yml > $@
 	sed -i "s/imagePullPolicy:.*/imagePullPolicy: Always/g" $@
 
-release: ## Create branch of new VERSION (and tag VERSION)
+release: ## Create branch of new VERSION (optionally tag VERSION)
+release: tag_release ?= no
 release: VERSION-required Pipfile.lock testsuite/resources/apicast.yml pipenv-dev
 	$(RUNSCRIPT)make-next-release $(VERSION)
 	git add testsuite/VERSION
 	git add -f Pipfile.lock
 	git add testsuite/resources/apicast.yml
 	git commit -m"`git rev-parse --abbrev-ref HEAD`"
-	git tag -a "`git rev-parse --abbrev-ref HEAD|cut -c9-`" -m"`git rev-parse --abbrev-ref HEAD`"
+	echo "$$tag_release" | egrep -iq '^(false|no|f|n|0)$$' || git tag -a "`git rev-parse --abbrev-ref HEAD|sed 's/^3scale-tests-//'`" -m"`git rev-parse --abbrev-ref HEAD`"
 	git rm --cached Pipfile.lock
 	git commit -m"Unfreeze Pipfile.lock after release"
 

--- a/scripts/make-next-release
+++ b/scripts/make-next-release
@@ -29,4 +29,4 @@ while f"v{nextver}" in tags:
 with open("VERSION", "w") as s:
     s.write(f"{version}.{revision}\n")
 
-run(["git", "checkout", "-b", f"release-v{version}.{revision}rc{rc}"], check=True)
+run(["git", "checkout", "-b", f"3scale-tests-v{version}.{revision}rc{rc}"], check=True)


### PR DESCRIPTION
This is github action to create new release of 3scale-tests
This is different from 'release' action:
 - 'release' does build and publish image of existing release.
 - 'create-release' creates release to be published later
Created release is not published automatically.
The process should be:
 - 'create-release'
 - merge it
 - create 'rc' tag/(github release) -> this will trigger 'release' action
 - test 'rc'
 - create final tag/github release) -> this will trigger 'release' action

I am not sure whether the action works actually ;-) -> likely try & fail approach in this case