### PR TITLE
Add gathering of apicast operator version

### DIFF
--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -5,6 +5,7 @@
 development:  # default dynaconf env
   threescale:
     version: "${THREESCALE_VERSION}"
+    apicast_opearator_version: "${APICAST_OPERATOR_VERSION}"
     superdomain: ${THREESCALE_SUPERDOMAIN}
     admin:
       url: ${ADMIN_URL}

--- a/config/settings.yaml.tpl
+++ b/config/settings.yaml.tpl
@@ -9,6 +9,7 @@ default:
   tester: whatever # used to create unique names for 3scale artifacts it defaults to whoami or uid
   threescale:  # now configure threescale details
     version: "{DEFAULT_THREESCALE_VERSION}"  # tested version used for example is some tests needs to be skipped
+    apicast_operator_version: "{DEFAULT_APICAST_OPERATOR_VERSION}"  # version of apicast operator used for example is some tests needs to be skipped
     superdomain: "{DEFAULT_THREESCALE_SUPERDOMAIN}"  # Threescale superdomain/wildcard_domain
     service:
       backends:  # list of backend services for testing

--- a/testsuite/__init__.py
+++ b/testsuite/__init__.py
@@ -74,5 +74,6 @@ else:
     os.environ["OPENSHIFT_CLIENT_PYTHON_DEFAULT_SKIP_TLS_VERIFY"] = "true"
 
 TESTED_VERSION = Version(str(settings["threescale"]["version"]))
+APICAST_OPERATOR_VERSION = Version(str(settings["threescale"]["apicast_operator_version"]))
 HTTP2 = settings.get("http2", False)
 ROOT_DIR = Path(os.path.abspath(__file__)).parent.parent

--- a/testsuite/openshift/client.py
+++ b/testsuite/openshift/client.py
@@ -222,6 +222,19 @@ class OpenShiftClient:
 
         return self.select_resource("pods", narrow_function=select_operator)
 
+    @property
+    def apicast_operator_subscription(self):
+        """
+        Gets the selector for the apicast-operator subscription
+
+        :return: the subscription
+        """
+
+        def select_operator(subscription):
+            return subscription.model.spec.name == "apicast-operator"
+
+        return self.select_resource("subscriptions", narrow_function=select_operator)
+
     def select_resource(self,
                         resource: str,
                         labels: Optional[Dict[str, str]] = None,

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -159,6 +159,9 @@ def pytest_report_header(config):
     threescale = settings["threescale"]["admin"]["url"]
     version = settings["threescale"]["version"]
     catalogsource = weakget(settings)["threescale"]["catalogsource"] % "UNKNOWN"
+    apicast_project = \
+        weakget(settings)["threescale"]["gateway"]["OperatorApicast"]["openshift"]["project_name"] % "None"
+    apicast_version = settings["threescale"]["apicast_operator_version"]
     toolboximage = weakget(settings)["toolbox"]["podman_image"].split(':')[-1] % "UNKNOWN"
 
     title = os.environ.get("JOB_NAME", "Ad-hoc").split()[0]
@@ -187,6 +190,8 @@ def pytest_report_header(config):
         f"testsuite: project = {project}",
         f"testsuite: threescale = {threescale}",
         f"testsuite: for 3scale version = {version}",
+        f"testsuite: Apicast operator project = {apicast_project}",
+        f"testsuite: for Apicast operator version = {apicast_version}",
         f"testsuite: catalogsource = {catalogsource}",
         f"testsuite: toolboximage = {toolboximage}",
         ""]

--- a/testsuite/tests/prometheus/apicast/selfmanaged/test_batching_caching_policy.py
+++ b/testsuite/tests/prometheus/apicast/selfmanaged/test_batching_caching_policy.py
@@ -5,11 +5,11 @@ from datetime import datetime, timedelta
 import pytest
 
 from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
+from testsuite import APICAST_OPERATOR_VERSION, rawobj  # noqa # pylint: disable=unused-import
 from testsuite.capabilities import Capability
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
+    pytest.mark.skipif("APICAST_OPERATOR_VERSION < Version('0.5.2')"),
     pytest.mark.required_capabilities(Capability.OCP4, Capability.APICAST),
     ]
 
@@ -70,7 +70,7 @@ def test_batcher_policy(prometheus, pod_monitor, api_client, staging_gateway, ap
     """Test if return correct number of usages of a service in batch"""
     client = api_client()
 
-    apicast_deployment = staging_gateway.deployment
+    apicast_deployment = staging_gateway.deployment.name
 
     metrics_keys = prometheus.get_metrics(apicast_deployment)
 


### PR DESCRIPTION
@mganisin I would have 2 questsions:
is the name TESTED_APICAST_VERSION ok, or would you suggest something different? APICAST_OPERATOR_VERSION ...
in get_apicast_operator: there is no clear label or other property that would specify subscription for Apicast operator, is it ok to expect that Apicast is the only operator in namespace?