### PR TITLE
Fix gateway logs

### DIFF
--- a/testsuite/gateway_logs.py
+++ b/testsuite/gateway_logs.py
@@ -58,7 +58,7 @@ def _print_logs(item, start_time, phase, suffix):
     # https://github.com/pytest-dev/pytest/issues/7724
     try:
         for gateway_name, gateway in item.gateways.items():
-            name = f"{gateway_name} - {suffix}"
+            name = f" {gateway_name} ({suffix}) "
             if Capability.LOGS in gateway.CAPABILITIES:
                 item.add_report_section(phase,
                                         "stdout",


### PR DESCRIPTION
* Incorrect phase names are gone!
   * Some requests do end up in the setup phase but usually due to shared Apicast in parallel runs
* Small formatting changes
* If the gateway logs fail in any way, they output it to stderr (Should not happen but nice to have)