### PR TITLE
TLS for ApicastOperator

### DIFF
--- a/testsuite/gateways/apicast/__init__.py
+++ b/testsuite/gateways/apicast/__init__.py
@@ -73,6 +73,10 @@ class OpenshiftApicast(AbstractApicast, ABC):
         """
         return False
 
+    @abstractmethod
+    def setup_tls(self, secret_name, https_port):
+        """Sets up TLS with the current gateway"""
+
     @property
     def deployment(self) -> Deployment:
         """Gateway deployment"""
@@ -166,3 +170,5 @@ class OpenshiftApicast(AbstractApicast, ABC):
                     "value": image
                 }
             ], patch_type="json")
+        # pylint: disable=protected-access
+        self.deployment.wait_for()

--- a/testsuite/gateways/apicast/operator.py
+++ b/testsuite/gateways/apicast/operator.py
@@ -168,6 +168,13 @@ class OperatorApicast(OpenshiftApicast):
 
         super().destroy()
 
+    def setup_tls(self, secret_name, https_port):
+        def _add_tls(apicast):
+            apicast["httpsPort"] = https_port
+            apicast["httpsCertificateSecretRef"] = {"name": secret_name}
+        self.apicast.modify_and_apply(_add_tls)
+        self.reload()
+
     def get_logs(self, since_time=None):
         return self.deployment.get_logs(since_time=since_time)
 

--- a/testsuite/gateways/apicast/tls.py
+++ b/testsuite/gateways/apicast/tls.py
@@ -1,35 +1,49 @@
 """Apicast with TLS certificates configured"""
 import logging
-from typing import Dict
+from datetime import datetime
+from typing import Optional
 
-from threescale_api.resources import Application
+from threescale_api.resources import Application, Service
 
 from testsuite.openshift.objects import Routes, SecretKinds
-from .template import TemplateApicast
+from . import AbstractApicast, OpenshiftApicast
+from .selfmanaged import SelfManagedApicast
+from .. import new_gateway
+from ... import settings
+from ...capabilities import Capability
 from ...certificates import Certificate
-from ...openshift.client import OpenShiftClient
+from ...openshift.env import Properties
 
 LOGGER = logging.getLogger(__name__)
 
 
-class TLSApicast(TemplateApicast):
-    """APIcast deployed with TLS certificates."""
+class TLSApicast(AbstractApicast):
+    """Apicast with TLS enabled, works for all subclasses of OpenshiftApicast (so both Template and Operator one)"""
 
-    # pylint: disable=too-many-arguments,too-many-instance-attributes
-    def __init__(self, staging: bool, openshift: OpenShiftClient, template, name, image, portal_endpoint, superdomain,
-                 server_authority, manager, generate_name=False, path_routing=False) -> None:
-        super().__init__(staging, openshift, template, name, image, portal_endpoint, generate_name, path_routing)
-        self.service_name = self.deployment.name
+    CAPABILITIES = {Capability.APICAST,
+                    Capability.CUSTOM_ENVIRONMENT,
+                    Capability.PRODUCTION_GATEWAY,
+                    Capability.LOGS,
+                    Capability.JAEGER}
+
+    # pylint: disable=too-many-arguments
+    def __init__(self, name, staging, superdomain, server_authority, manager, generate_name=False) -> None:
+        super().__init__()
+        # We expect that the SelfManagedApicast returns subclass of OpenshiftApicast,
+        # which is for now true, but it is not ensured
+        self.gateway: OpenshiftApicast = new_gateway({}, kind=SelfManagedApicast, staging=staging,  # type: ignore
+                                                     settings_=settings["threescale"]["gateway"],
+                                                     name=name, randomize_name=generate_name)
+        # Ugly monkey-patching of a method
+        self.gateway.add_route = self.add_route  # type: ignore
+        self.secret_name = self.gateway.deployment.name
         self.superdomain = superdomain
         self.server_authority = server_authority
         self.manager = manager
-        self.secret_name = f"{self.deployment.name}-server-authority"
-        self.volume_name = f"{self.deployment.name}-volume"
-        self.mount_path = "/var/apicast/secrets"
-        self.https_port = 8443
 
     @property
     def _hostname(self):
+        """Return wildcard hostname for certificates"""
         return f"*.{self.superdomain}"
 
     @property
@@ -40,73 +54,56 @@ class TLSApicast(TemplateApicast):
                                           hosts=[self._hostname],
                                           certificate_authority=self.server_authority)
 
+    def on_application_create(self, application: Application):
+        application.api_client_verify = self.server_authority.files["certificate"]
+
+    def before_service(self, service_params: dict) -> dict:
+        return self.gateway.before_service(service_params)
+
+    def before_proxy(self, service: Service, proxy_params: dict):
+        return self.gateway.before_proxy(service, proxy_params)
+
+    def on_service_delete(self, service: Service):
+        self.gateway.on_service_delete(service)
+
     def add_route(self, name, kind=Routes.Types.PASSTHROUGH):
         """Adds new route for this APIcast"""
         hostname = f"{name}.{self.superdomain}"
         result = self.openshift.routes.create(name, kind, hostname=hostname,
-                                              service=self.deployment.name, port="https")
-        self._routes.append(name)
+                                              service=self.deployment.name, port="httpsproxy")
+        # pylint: disable=protected-access
+        self.gateway._routes.append(name)
         return result
 
-    def on_application_create(self, application: Application):
-        application.api_client_verify = self.server_authority.files["certificate"]
+    def create(self):
+        super().create()
+        self.gateway.create()
 
-    def get_patch_data(self) -> Dict:
-        """Returns patch data for enabling https port on service."""
-        return {
-            "spec": {
-                "ports": [
-                    {
-                        "name": "https",
-                        "port": self.https_port,
-                        "protocol": "TCP"
-                    }
-                ],
-            }
-        }
-
-    def _add_envs(self):
-        LOGGER.debug('Adding envs to deployment "%s"...', self.deployment)
-
-        envs = {
-            "APICAST_HTTPS_PORT": self.https_port,
-            "APICAST_HTTPS_CERTIFICATE": f"{self.mount_path}/tls.crt",
-            "APICAST_HTTPS_CERTIFICATE_KEY": f"{self.mount_path}/tls.key",
-        }
-        LOGGER.debug(envs)
-        self.environ.set_many(envs)
-
-    def _create_secret(self):
         LOGGER.debug('Creating tls secret "%s"...', self.secret_name)
-
         self.openshift.secrets.create(name=self.secret_name, kind=SecretKinds.TLS, certificate=self.server_certificate)
 
-    def create(self):
-        """Deploy TLS Apicast."""
-
-        super().create()
-
-        self._create_secret()
-
-        LOGGER.debug('Adding volume "%s" bound to secret "%s" to deployment "%s"...',
-                     self.volume_name, self.secret_name, self.deployment)
-        self.deployment.add_volume(self.volume_name, self.mount_path, self.secret_name)
-
-        self._add_envs()
-
-        LOGGER.debug('Patching service "%s". Payload "%s"...', self.service_name, self.get_patch_data())
-        self.openshift.patch("service", self.service_name, self.get_patch_data())
-
-        LOGGER.debug('TLS apicast "%s" has been deployed!', self.deployment)
+        self.gateway.setup_tls(self.secret_name, 8443)
 
     def destroy(self):
-        """Destroy TLS Apicast."""
-
         super().destroy()
+        self.gateway.destroy()
 
         LOGGER.debug('Deleting secret "%s"', self.secret_name)
         self.openshift.delete("secret", self.secret_name)
 
-        LOGGER.debug('TLS apicast "%s" has been destroyed!', self.deployment.name)
-
         self.server_certificate.delete_files()
+
+    @property
+    def environ(self) -> Properties:
+        return self.gateway.environ
+
+    def reload(self):
+        self.gateway.reload()
+
+    def get_logs(self, since_time: Optional[datetime] = None) -> str:
+        return self.gateway.get_logs(since_time)
+
+    def __getattr__(self, item):
+        if hasattr(self.gateway, item):
+            return getattr(self.gateway, item)
+        raise AttributeError(f"{self.__class__.__name__} object has no attribute {item}")

--- a/testsuite/tests/apicast/policy/tls/conftest.py
+++ b/testsuite/tests/apicast/policy/tls/conftest.py
@@ -44,14 +44,13 @@ def server_authority(request, superdomain, manager):
 
 
 @pytest.fixture(scope="module")
-def staging_gateway(request, testconfig, server_authority, superdomain, manager):
+def staging_gateway(request, server_authority, superdomain, manager):
     """Deploy tls apicast gateway. We need APIcast listening on https port"""
     kwargs = dict(
         name=blame(request, "tls-gw"),
         manager=manager,
         server_authority=server_authority,
-        superdomain=superdomain,
-        **testconfig["threescale"]["gateway"]["TemplateApicast"],
+        superdomain=superdomain
     )
     gw = gateway(kind=TLSApicast, staging=True, **kwargs)
 

--- a/testsuite/tests/apicast/policy/tls/test_tls_termination_policy.py
+++ b/testsuite/tests/apicast/policy/tls/test_tls_termination_policy.py
@@ -37,7 +37,7 @@ def path_policy_settings(request, certificate, mount_certificate_secret):
 
 @pytest.fixture(scope="module", params=(
         pytest.param("embedded_policy_settings", id="Embedded"),
-        pytest.param("path_policy_settings", id="Path")
+        pytest.param("path_policy_settings", id="Path", marks=pytest.mark.required_capabilities(Capability.OCP3))
 ))
 def policy_settings(request):
     """TLS termination policy settings"""

--- a/testsuite/tests/apicast/policy/tls/tls_upstream/conftest.py
+++ b/testsuite/tests/apicast/policy/tls/tls_upstream/conftest.py
@@ -70,13 +70,12 @@ def httpbin(custom_httpbin, request):
 
 # pylint: disable=too-many-arguments
 @pytest.fixture(scope="module")
-def custom_httpbin(staging_gateway, request, upstream_certificate, upstream_authority, openshift, testconfig):
+def custom_httpbin(staging_gateway, request, upstream_certificate, upstream_authority, testconfig):
     """
     Deploys httpbin with a custom name with mTLS enabled.
     If tls_route_type is set, creates routes for the backend with given TLS type
     and returns the public route of the backend.
     """
-    openshift = openshift()
     httpbin_image = testconfig["fixtures"]["custom_httpbin"]["image"]
 
     def _httpbin(name, tls_route_type=None):
@@ -97,9 +96,9 @@ def custom_httpbin(staging_gateway, request, upstream_certificate, upstream_auth
         staging_gateway.openshift.deployment(f"dc/{name}").wait_for()
 
         if tls_route_type is not None:
-            request.addfinalizer(lambda: openshift.delete("route", name))
-            openshift.routes.create(name, tls_route_type, service=name)
-            routes = openshift.routes[name]
+            request.addfinalizer(lambda: staging_gateway.openshift.delete("route", name))
+            staging_gateway.openshift.routes.create(name, tls_route_type, service=name)
+            routes = staging_gateway.openshift.routes[name]
             return f"https://{routes['spec']['host']}:443"
 
         return f"https://{name}:8443"

--- a/testsuite/tests/apicast/policy/tls/tls_upstream/mtls_apicast_cert_validation/test_upstream_mtls_policy.py
+++ b/testsuite/tests/apicast/policy/tls/tls_upstream/mtls_apicast_cert_validation/test_upstream_mtls_policy.py
@@ -43,7 +43,7 @@ def path_policy_settings(request, certificate, mount_certificate_secret):
 
 @pytest.fixture(scope="module", params=(
         pytest.param("embedded_policy_settings", id="Embedded"),
-        pytest.param("path_policy_settings", id="Path")
+        pytest.param("path_policy_settings", id="Path", marks=pytest.mark.required_capabilities(Capability.OCP3))
 ))
 def policy_settings(request):
     """Paramterized policy settings for upstream mTLS policy"""


### PR DESCRIPTION
* Rewrite TLSGateway to work with both Template and OperatorApicast
   * Moved the actual TLS setup into the individual classes
* Update TLS tests to work with this new gateway
   * Notably, path_policy doesn't work on OperatorApicast as we cannot mount an arbitrary volume to it.