### PR TITLE
Update Jaeger tests

### DIFF
--- a/testsuite/gateways/apicast/__init__.py
+++ b/testsuite/gateways/apicast/__init__.py
@@ -1,7 +1,7 @@
 """Module containing all APIcast gateways"""
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Optional, List, Dict
+from typing import Optional, List, Dict, Tuple
 import logging
 
 from threescale_api.resources import Service
@@ -37,6 +37,7 @@ class AbstractApicast(AbstractGateway, ABC):
         pass
 
 
+# pylint: disable=too-many-instance-attributes
 class OpenshiftApicast(AbstractApicast, ABC):
     """Super-class for selfmanaged apicast deployed to openshift"""
 
@@ -62,6 +63,7 @@ class OpenshiftApicast(AbstractApicast, ABC):
             self.name = f"{name}-{utils.randomize(utils._whoami()[:8])}"
         self._routes: List[str] = []
         self._base_route = None
+        self._to_delete: List[Tuple[str, str]] = []
 
     @staticmethod
     def fits(openshift: OpenShiftClient):  # pylint: disable=unused-argument
@@ -98,6 +100,9 @@ class OpenshiftApicast(AbstractApicast, ABC):
             if route in self.openshift.routes:
                 LOGGER.debug('Removing route "%s"...', route)
                 del self.openshift.routes[route]
+
+        for kind, name in self._to_delete:
+            self.openshift.delete(kind, name)
 
     def create(self):
         super().create()

--- a/testsuite/gateways/apicast/template.py
+++ b/testsuite/gateways/apicast/template.py
@@ -73,19 +73,19 @@ class TemplateApicast(OpenshiftApicast):
         LOGGER.debug('Deleting secret "%s"', self.template_parameters["CONFIGURATION_URL_SECRET"])
         self.openshift.delete("secret", self.template_parameters["CONFIGURATION_URL_SECRET"])
 
-    def connect_jaeger(self, jaeger, jaeger_randomized_name):
+    def connect_jaeger(self, jaeger):
         """
         Modifies the APIcast to send information to jaeger.
         Creates configmap and a volume, mounts the configmap into the volume
         Updates the required env vars
         :param jaeger instance of the Jaeger class carrying the information about the apicast_configuration
-        :param jaeger_randomized_name: randomized name used for the name of the configmap and for
-               the identifying name of the service in jaeger
+        :returns Name of the jaeger service
         """
-        service_name = jaeger_randomized_name
-        config_map_name = f"{jaeger_randomized_name}.json"
-        self.openshift.config_maps.add(config_map_name, jaeger.apicast_config(config_map_name, service_name))
+        config_map_name = f"{self.name}-jaeger"
+        self.openshift.config_maps.add(config_map_name, jaeger.apicast_config(config_map_name, self.name))
+        self._to_delete.append(("configmap", config_map_name))
         self.deployment.add_volume("jaeger-config-vol", "/tmp/jaeger/",
                                    configmap_name=config_map_name)
         self.environ.set_many({"OPENTRACING_TRACER": "jaeger",
                                "OPENTRACING_CONFIG": f"/tmp/jaeger/{config_map_name}"})
+        return self.name

--- a/testsuite/tests/apicast/parameters/jaeger/conftest.py
+++ b/testsuite/tests/apicast/parameters/jaeger/conftest.py
@@ -5,7 +5,6 @@ Conftest for the jaeger tests
 from weakget import weakget
 import pytest
 
-from testsuite.utils import blame
 from testsuite.jaeger import Jaeger
 
 

--- a/testsuite/tests/apicast/parameters/jaeger/conftest.py
+++ b/testsuite/tests/apicast/parameters/jaeger/conftest.py
@@ -23,18 +23,8 @@ def jaeger(testconfig, tools):
 
 
 @pytest.fixture(scope="module")
-def jaeger_randomized_name(request):
-    """
-    Randomized name for the jaeger configmap and for the jaeger service_name used
-    when querying the services
-    """
-    return f"{blame(request, 'jaeger')}"
-
-
-@pytest.fixture(scope="module")
-def staging_gateway(staging_gateway, jaeger, jaeger_randomized_name):
+def jaeger_service_name(staging_gateway, jaeger):
     """
     Deploys template apicast gateway configured with jaeger.
     """
-    staging_gateway.connect_jaeger(jaeger, jaeger_randomized_name)
-    return staging_gateway
+    return staging_gateway.connect_jaeger(jaeger)

--- a/testsuite/tests/apicast/parameters/jaeger/test_jaeger_apicast_integration.py
+++ b/testsuite/tests/apicast/parameters/jaeger/test_jaeger_apicast_integration.py
@@ -6,14 +6,19 @@ It is necessary to have the jaeger url config value set
 import backoff
 import pytest
 
+from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 from testsuite.utils import randomize
 from testsuite.capabilities import Capability
 
 CAPABILITIES = [Capability.JAEGER]
 
 
-# seems to fail everytime actually
-@pytest.mark.flaky
+@pytest.fixture(scope="module")
+def gateway_kind():
+    """Gateway class to use for tests"""
+    return SelfManagedApicast
+
+
 @pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-5669")
 def test_jaeger_apicast_integration(api_client, jaeger, jaeger_service_name):
     """

--- a/testsuite/tests/apicast/parameters/jaeger/test_jaeger_apicast_integration.py
+++ b/testsuite/tests/apicast/parameters/jaeger/test_jaeger_apicast_integration.py
@@ -15,10 +15,9 @@ CAPABILITIES = [Capability.JAEGER]
 # seems to fail everytime actually
 @pytest.mark.flaky
 @pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-5669")
-def test_jaeger_apicast_integration(api_client, jaeger, jaeger_randomized_name):
+def test_jaeger_apicast_integration(api_client, jaeger, jaeger_service_name):
     """
     Makes a request to a random endpoint
-    :param jaeger_randomized_name the identifying name of the service in jaeger
     Tests that:
      1) data from the jaeger contain a trace where with the http.url tag in the span
         with the '/' operationName has the value containing the randomized endpoint
@@ -32,7 +31,7 @@ def test_jaeger_apicast_integration(api_client, jaeger, jaeger_randomized_name):
     @backoff.on_predicate(backoff.fibo, lambda x: not x, 8, jitter=None)
     def request_traced():
         """Let's retry as the tracing might be 'lazy'"""
-        traces = jaeger.traces(jaeger_randomized_name, "/")
+        traces = jaeger.traces(jaeger_service_name, "/")
         for trace in traces['data']:
             for span in trace['spans']:
                 if span['operationName'] == '/':
@@ -43,7 +42,7 @@ def test_jaeger_apicast_integration(api_client, jaeger, jaeger_randomized_name):
 
     assert request_traced()
 
-    traces = jaeger.traces(jaeger_randomized_name, "/")
+    traces = jaeger.traces(jaeger_service_name, "/")
     url_and_uri = True
     for trace in traces['data']:
         for span in trace['spans']:


### PR DESCRIPTION
* Add cleanup of the configmap
   * This was done by adding `to_delete` list to `OpenshiftApicast`
* Simplify naming of said configmap.
* Add support for `ApicastOperator`
* Remove flaky mark