### PR TITLE
Added a full-page (multiple screenshots) screenshot functionality

### DIFF
--- a/testsuite/tests/ui/conftest.py
+++ b/testsuite/tests/ui/conftest.py
@@ -288,8 +288,7 @@ def pytest_exception_interact(node, call, report):
         browser = node.funcargs.get("browser")
         if not browser:
             return
-        screenshot = os.path.join(get_resultsdir_path(node), "failed-test-screenshot.png")
-        browser.selenium.save_screenshot(screenshot)
+        fullpage_screenshot(driver=browser.selenium, file_path=get_resultsdir_path(node))
 
 
 def get_resultsdir_path(node):
@@ -320,6 +319,29 @@ def get_resultsdir_path(node):
         os.makedirs(path)
 
     return path
+
+
+def fullpage_screenshot(driver, file_path):
+    """
+        A full-page screenshot function. It scroll the website and screenshots it.
+        - Creates multiple files
+        - Screenshots are made only vertically (on Y axis)
+    """
+    # Removal of the height: 100% style, that disables scroll.
+    driver.execute_script("document.body.style.height = 'unset'")
+    driver.execute_script("document.body.parentNode.style.height = 'unset'")
+
+    total_height = driver.execute_script("return document.body.parentNode.scrollHeight")
+    viewport_height = driver.execute_script("return window.innerHeight")
+    tolerance = 50     # Google chrome on 'window.innerHeight' returns the size of the whole window, not the viewport
+    scroll_height = viewport_height - tolerance
+    part = 0
+
+    for scroll in range(0, total_height, scroll_height):
+        driver.execute_script("window.scrollTo({0}, {1})".format(0, scroll))
+        file_name = file_path + "part_{0}.png".format(part)
+        driver.get_screenshot_as_file(file_name)
+        part += 1
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This PR adds the code that generates multiple images regarding the height of the website. Because of some CSS related stuff, the HTML of the website had to be altered (2 styles were added).

At first, I wanted to create 1 big screenshot of the website. Problem is that even the existing libraries are having trouble to make a perfect fullscreen image of the website when using selenium (Google chrome for some reason does not return correct values about the height of the website (atleast to me it is not) and Firefox has integrated a fullscreen capturing). 

To be a bit more specific, what happens is that google chrome (chromedriver) returns a height of the website viewport equal to `839px`, but makes a screenshot of a height of `891px`. I have no idea why this is happening, it works perfectly on firefox, but not on Chrome. 

In order to merge 2 png files, we would need to get dimensions of the screenshot and create a metric that will allow us to create the whole image (I have tried to do something simillar a while ago but I was not successful. Therefore for now, the website split into the multiple images with offset (so that nothing gets lost) will hopefully be enough. 