### PR TITLE
Add configurable httpbin-go image

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -40,6 +40,8 @@ default:
   fixtures:
     tools:
       namespace: tools
+    custom_httpbin:
+      image: quay.io/jsmadis/go-httpbin:latest
     lifecycle_hooks:
       defaults: [staging_gateway, production_gateway]
     jaeger:

--- a/testsuite/resources/tls/httpbin_go.yaml
+++ b/testsuite/resources/tls/httpbin_go.yaml
@@ -50,7 +50,7 @@ objects:
                 value: '8443'
               - name: MTLS_ENABLED
                 value: '1'
-              image: ${IMG_HTTPBIN_GOHTTPBIN}
+              image: ${IMAGE}
               imagePullPolicy: IfNotPresent
               name: go-httpbin
               ports:
@@ -100,7 +100,6 @@ parameters:
 - name: CA_CERTIFICATE
   description: "Certificate Authority"
   required: true
-- name: IMG_HTTPBIN_GOHTTPBIN
+- name: IMAGE
   description: Go httpbin image to use
   required: true
-  value: quay.io/jsmadis/go-httpbin:latest

--- a/testsuite/tests/apicast/policy/tls/tls_upstream/conftest.py
+++ b/testsuite/tests/apicast/policy/tls/tls_upstream/conftest.py
@@ -68,14 +68,16 @@ def httpbin(custom_httpbin, request):
     return custom_httpbin(blame(request, "httpbin-mtls"))
 
 
+# pylint: disable=too-many-arguments
 @pytest.fixture(scope="module")
-def custom_httpbin(staging_gateway, request, upstream_certificate, upstream_authority, openshift):
+def custom_httpbin(staging_gateway, request, upstream_certificate, upstream_authority, openshift, testconfig):
     """
     Deploys httpbin with a custom name with mTLS enabled.
     If tls_route_type is set, creates routes for the backend with given TLS type
     and returns the public route of the backend.
     """
     openshift = openshift()
+    httpbin_image = testconfig["fixtures"]["custom_httpbin"]["image"]
 
     def _httpbin(name, tls_route_type=None):
         path = resources.files('testsuite.resources.tls').joinpath('httpbin_go.yaml')
@@ -85,6 +87,7 @@ def custom_httpbin(staging_gateway, request, upstream_certificate, upstream_auth
             "CERTIFICATE": upstream_certificate.certificate,
             "CERTIFICATE_KEY": upstream_certificate.key,
             "CA_CERTIFICATE": upstream_authority.certificate,
+            "IMAGE": httpbin_image
         }
 
         request.addfinalizer(


### PR DESCRIPTION
This should help with running TLS tests on non-x86 archs