### PR TITLE
Fix RHSSO token performance test

### DIFF
--- a/testsuite/tests/performance/smoke/test_smoke_rhsso_tokens.py
+++ b/testsuite/tests/performance/smoke/test_smoke_rhsso_tokens.py
@@ -5,6 +5,7 @@
     This test shows usage how to write test where access token is created by performance test.
 """
 import os
+from urllib.parse import urlparse
 
 import backoff
 import pytest
@@ -44,7 +45,8 @@ def template(root_path):
 def setup_benchmark(hyperfoil_utils, promoted_services, applications, rhsso_service_info, shared_template):
     """Setup of benchmark. It will add necessary host connections, csv data and files."""
     hyperfoil_utils.add_hosts(promoted_services, shared_connections=20)
-    hyperfoil_utils.add_host(rhsso_service_info.rhsso.server_url, shared_connections=100)
+    hyperfoil_utils.add_host(
+        urlparse(rhsso_service_info.rhsso.server_url)._replace(path="").geturl(), shared_connections=100)
     hyperfoil_utils.add_token_creation_data(rhsso_service_info, applications, 'rhsso_auth.csv')
     hyperfoil_utils.add_file(HyperfoilUtils.message_1kb)
     hyperfoil_utils.add_shared_template(shared_template)


### PR DESCRIPTION
- Same fix as in RHOAM version ("new" RHSSO library points to auth/ endpoint, which hyperfoil doesn't like)
- Won't pass without #191 