### PR TITLE
Remove typing from new_app

### DIFF
--- a/testsuite/openshift/client.py
+++ b/testsuite/openshift/client.py
@@ -194,7 +194,7 @@ class OpenShiftClient:
         for resource in processed_tmpl["items"]:
             self.delete(resource['kind'], resource['metadata']['name'])
 
-    def new_app(self, source: str, params: Dict[str, str] = None):
+    def new_app(self, source, params: Dict[str, str] = None):
         """Create application based on source code.
 
         Args:


### PR DESCRIPTION
`importlib_resources` added types and it is weird and causing pipeline failure. Simplest way to fix this is to simply remove typing in new_app 