### PR TITLE
github action to craete tagged github release

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,0 +1,19 @@
+name: tag release
+on:
+  pull_request:
+    types: [closed]
+    paths: [testsuite/VERSION]
+
+jobs:
+  tag_release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: tag release
+        shell: bash
+        run: git log --no-merges --pretty=oneline|grep 'v[0-9.]*rc[0-9]*'|head -1|(read COMMIT MSG; gh release create "v${MSG##*-v}" -p --generate-notes --target $COMMIT)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Simple action to coop with 'create release' action. (too much
'*release*' actions, some polishing may be needed in future).

This removes one extra manual step when creating a release, it creates
release (and tag) for RC release once RC branch/PR (created by "create
release" is merged). Obviously it depends on format of relevant commit
message.

Now the release process is:x
 1) Run "create release" action.
 2) Review & merge created PR
 3) Test RC image when created
 4) Manually create final github release
