### PR TITLE
Include gateway name in routes for SelfManagedApicast

### DIFF
--- a/testsuite/gateways/apicast/__init__.py
+++ b/testsuite/gateways/apicast/__init__.py
@@ -84,9 +84,7 @@ class OpenshiftApicast(AbstractApicast, ABC):
 
     def _routename(self, service):
         """name of route for given service"""
-        route = f"{service.entity_id}"
-        if self.staging:
-            route = f"{route}-stage"
+        route = f"{service.entity_id}-{self.name}"
         return route
 
     @property

--- a/testsuite/tests/apicast/parameters/test_apicast_service.py
+++ b/testsuite/tests/apicast/parameters/test_apicast_service.py
@@ -64,7 +64,7 @@ def test_filter_by_url(api_client_pass, api_client_fail, staging_gateway, servic
     Request to 'service_pass' should return 200
     Request to 'service_fail' should return 404
     """
-    public_url = f".*{service_pass.entity_id}-stage.*"
+    public_url = f".*{service_pass.entity_id}-{staging_gateway.name}.*"
     staging_gateway.environ["APICAST_SERVICES_FILTER_BY_URL"] = public_url
 
     request = api_client_pass.get("/get")


### PR DESCRIPTION
This will fix rare instance where multiple 3scales use the same operator and services have the same id