### PR TITLE
Let action creating pre-release trigger event

### DIFF
--- a/.github/workflows/github_pre_release.yaml
+++ b/.github/workflows/github_pre_release.yaml
@@ -1,19 +1,20 @@
-name: tag release
+name: github_pre_release
 on:
   pull_request:
     types: [closed]
     paths: [testsuite/VERSION]
 
 jobs:
-  tag_release:
+  github_pre_release:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: tag release
+      - name: github_pre_release
         shell: bash
         run: git log --no-merges --pretty=oneline|grep 'v[0-9.]*rc[0-9]*'|head -1|(read COMMIT MSG; gh release create "v${MSG##*-v}" -p --generate-notes --target $COMMIT)
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # github-actions account doesn't seem to trigger events, therefore different account must be used
+          GITHUB_TOKEN: ${{ secrets.BOTBEZBOT_TOKEN }}


### PR DESCRIPTION
It looks like github-actions account (and token) does not trigger
further events. That's problem because another action is bound to
push:tags that should be triggered by new github release.

Running this action under another account should be working workaround.
