### PR TITLE
Fixed tests failing due to malformed XPath

### DIFF
--- a/testsuite/ui/views/admin/product/integration/settings.py
+++ b/testsuite/ui/views/admin/product/integration/settings.py
@@ -30,12 +30,12 @@ class ProductSettingsView(BaseProductView):
 
     def change_authentication(self, option):
         """Change authentication"""
-        self.authentication.select([option])
+        self.authentication.select(option)
         self.update_button.click()
 
     def change_deployment(self, option):
         """Change deployment"""
-        self.deployment.select([option])
+        self.deployment.select(option)
         self.update_button.click()
 
     def prerequisite(self):

--- a/testsuite/ui/widgets/__init__.py
+++ b/testsuite/ui/widgets/__init__.py
@@ -223,7 +223,7 @@ class ThreescaleCheckBox(GenericLocatorWidget):
 # an abstract method
 class DeploymentRadio(RadioGroup):
     """Variation of 3scale radio group"""
-    OPTIONS_SECTION = './/li[@id="{}"]/fieldset/ol'
+    OPTIONS_SECTION = '/fieldset/ol'
 
     OPTIONS = './/li'
     OPTIONS_BY_ID = OPTIONS + '/label/input[@id="{}"]'


### PR DESCRIPTION
These tests were failing:
* testsuite.tests.ui.apiap.test_config_version_update_azp_values : test_config_version
* testsuite.tests.ui.apiap.test_product : test_proxy_settings