### PR TITLE
One SSO realm for whole testing session

### DIFF
--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -450,7 +450,7 @@ def production_gateway(request, testconfig, openshift):
     return gateway
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def rhsso_service_info(request, testconfig, tools):
     """
     Set up client for zync


### PR DESCRIPTION
Due to known issue in RHSSO there is a problem with frequent creation of
roles/realms. Therefore reducing realm creation can improve stability of
tests.
https://github.com/keycloak/keycloak/issues/8772
