### PR TITLE
Exclude some operator bound tests from speedrun

### DIFF
--- a/testsuite/tests/apicast/parameters/test_modular_apicast.py
+++ b/testsuite/tests/apicast/parameters/test_modular_apicast.py
@@ -19,7 +19,8 @@ from testsuite.gateways.apicast.template import TemplateApicast
 from testsuite.utils import blame
 
 pytestmark = [pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY),
-              pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-553")]
+              pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-553"),
+              pytest.mark.sandbag]  # explicit requirement of operator apicast - doesn't have to be available
 
 
 @pytest.fixture(scope="module", params=[

--- a/testsuite/tests/operator/test_apicast_operator_labels.py
+++ b/testsuite/tests/operator/test_apicast_operator_labels.py
@@ -12,6 +12,7 @@ from testsuite.capabilities import Capability
 pytestmark = [
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-7751"),
     pytest.mark.required_capabilities(Capability.OCP4),
+    pytest.mark.sandbag  # requires apicast operator, doesn't have to be available
 ]
 
 LABELS_PRE_2_12: List[Union[Tuple[str, str], Tuple[str, None]]] = [

--- a/testsuite/tests/operator/test_labels.py
+++ b/testsuite/tests/operator/test_labels.py
@@ -11,6 +11,7 @@ from testsuite.capabilities import Capability
 from testsuite.configuration import openshift
 
 pytestmark = [
+    pytest.mark.sandbag,  # requires operator in same namespace
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-7750"),
     pytest.mark.required_capabilities(Capability.OCP4),
 ]


### PR DESCRIPTION
There are some silent assumptions regarding to deployments of operators
that aren't true in every case.
