### PR TITLE
Change devel version number to sométhing more obscure

### DIFF
--- a/testsuite/dynaconf_loader.py
+++ b/testsuite/dynaconf_loader.py
@@ -71,8 +71,9 @@ def _guess_apicast_operator_version(ocp):
         version = version.split("-")[0]
         Version(version)
     except (ValueError, IndexError, OpenShiftPythonException, InvalidVersion):
-        return "2022"  # returning value that is greater than any apicast version
+        # returning value that is greater than any apicast version
         # in result all tests for latest apicast operator will run
+        return "50035350"  # doesn't have to be spot at first glance, this is literal transcript of word "devel"
 
     return str(version)
 


### PR DESCRIPTION
Original devel version number "2022" wasn't clear enough that this is
something special, here is a suggestion for something bit more
representative. Btw. something like 10000000 might be even better (if it
can be clearly represented by number at all), but suggested value is "funny".
