### PR TITLE
Read resource by name in UI tests with default backoff

### DIFF
--- a/testsuite/resilient.py
+++ b/testsuite/resilient.py
@@ -9,3 +9,16 @@ def stats_service_usage(threescale, service_id, metric_name, key, threshold=0):
     value = threescale.analytics.list_by_service(service_id, metric_name=metric_name)[key]
     assert value >= threshold
     return value
+
+
+@backoff.on_predicate(backoff.fibo, lambda x: x is None, max_tries=7, jitter=None)
+def resource_read_by_name(object_instance, name: str):
+    """
+    Method add backoff function to read_by_name function of specified resource
+    e.g. threescale. Should be used mainly in UI tests due to slower execution
+    in UI vs API.
+    @param object_instance: instance of the object e.g. threescale, threescale.backends
+    @param name: Name of the specific resource to search for
+    @return: Desired resource object
+    """
+    return object_instance.read_by_name(name)

--- a/testsuite/tests/ui/apiap/test_backend.py
+++ b/testsuite/tests/ui/apiap/test_backend.py
@@ -1,6 +1,7 @@
 """Rewrite of spec/ui_specs/api_as_a_product/create_backend_spec.rb.rb"""
 import pytest
 
+from testsuite import resilient
 from testsuite.utils import blame
 from testsuite.ui.views.admin.backend.backend import BackendEditView
 
@@ -37,7 +38,7 @@ def test_edit_backend(login, navigator, custom_backend, threescale):
     edit = navigator.navigate(BackendEditView, backend=backend)
 
     edit.update("updated_name", "updated_description", "https://updated_endpoint")
-    backend = threescale.backends.read_by_name(backend.entity_name)
+    backend = resilient.resource_read_by_name(threescale.backends, backend.entity_name)
 
     assert backend["name"] == "updated_name"
     assert backend["description"] == "updated_description"

--- a/testsuite/tests/ui/apiap/test_product.py
+++ b/testsuite/tests/ui/apiap/test_product.py
@@ -6,7 +6,7 @@ from testsuite.ui.views.admin.product.application import ApplicationPlanDetailVi
 from testsuite.ui.views.admin.product.integration.settings import ProductSettingsView
 from testsuite.ui.views.admin.product.integration.configuration import ProductConfigurationView
 from testsuite.ui.views.admin.product.integration.backends import ProductBackendsView, ProductAddBackendView
-from testsuite import rawobj
+from testsuite import rawobj, resilient
 from testsuite.utils import blame
 
 
@@ -59,7 +59,7 @@ def test_edit_product(login, navigator, service, threescale):
     """
     edit = navigator.navigate(ProductEditView, product=service)
     edit.update("updated_name", "updated_description")
-    product = threescale.services.read_by_name(service.entity_name)
+    product = resilient.resource_read_by_name(threescale.services, service.entity_name)
 
     assert product["name"] == "updated_name"
     assert product["description"] == "updated_description"
@@ -113,7 +113,7 @@ def test_update_proxy_url(service, login, navigator, threescale):
     """
     settings = navigator.navigate(ProductSettingsView, product=service)
     settings.update_gateway("https://staging.anything.invalid:443", "https://production.anything.invalid:443")
-    product = threescale.services.read_by_name(service.entity_name)
+    product = resilient.resource_read_by_name(threescale.services, service.entity_name)
     proxy = product.proxy.list()
 
     assert proxy["sandbox_endpoint"] == "https://staging.anything.invalid:443"
@@ -130,7 +130,7 @@ def test_assign_backend_to_product(login, navigator, ui_backend, ui_product, thr
     """
     backend = navigator.navigate(ProductAddBackendView, product=ui_product)
     backend.add_backend(ui_backend, "/get")
-    ui_product = threescale.services.read_by_name(ui_product.entity_name)
+    ui_product = resilient.resource_read_by_name(threescale.services, ui_product.entity_name)
     backends = ui_product.backend_usages.list()
 
     assert len(backends) == 1

--- a/testsuite/tests/ui/auth/conftest.py
+++ b/testsuite/tests/ui/auth/conftest.py
@@ -4,6 +4,7 @@ Conftest for auth tests
 # pylint: disable=unused-argument, too-many-arguments
 import pytest
 
+from testsuite import resilient
 from testsuite.ui.views.admin.settings.sso_integrations import NewSSOIntegrationView, SSOIntegrationEditView, \
     SSOIntegrationDetailView
 from testsuite.ui.views.auth import Auth0View, RhssoView
@@ -59,7 +60,7 @@ def auth0_setup(custom_admin_login, testconfig, ui_sso_integration, navigator, s
 
     if not testconfig["skip_cleanup"]:
         name = auth0_user["email"].split("@")[0]
-        user = threescale.provider_account_users.read_by_name(name)
+        user = resilient.resource_read_by_name(threescale.provider_account_users, name)
         user.delete()
 
 
@@ -106,7 +107,8 @@ def rhsso_setup(request, custom_admin_login, rhsso_service_info, ui_sso_integrat
     sso.publish()
 
     def _delete():
-        user = threescale.provider_account_users.read_by_name(admin.get_user(rhsso_service_info.user)["username"])
+        user = resilient.resource_read_by_name(threescale.provider_account_users,
+                                               admin.get_user(rhsso_service_info.user)["username"])
         user.delete()
 
     request.addfinalizer(_delete)

--- a/testsuite/tests/ui/master/test_tenant.py
+++ b/testsuite/tests/ui/master/test_tenant.py
@@ -3,6 +3,7 @@
 """
 import pytest
 
+from testsuite import resilient
 from testsuite.ui.views.admin.login import LoginView
 from testsuite.ui.views.common.foundation import NotFoundView
 from testsuite.utils import blame
@@ -85,7 +86,7 @@ def test_delete_tenant(master_login, navigator, master_threescale, custom_tenant
 
     detail_view = navigator.navigate(TenantDetailView, account=tenant)
 
-    account_deleted = master_threescale.accounts.read_by_name(account.entity_name)
+    account_deleted = resilient.resource_read_by_name(master_threescale.accounts, account.entity_name)
     assert account_deleted.entity['state'] == 'scheduled_for_deletion'
 
     assert_displayed_in_new_tab(browser, detail_view.open_public_domain, NotFoundView)
@@ -112,7 +113,7 @@ def test_resume_tenant(master_login, navigator, master_threescale, custom_tenant
     # resume tenant from deletion
     detail_view.resume()
 
-    account_deleted = master_threescale.accounts.read_by_name(account.entity_name)
+    account_deleted = resilient.resource_read_by_name(master_threescale.accounts, account.entity_name)
     assert account_deleted.entity['state'] != 'scheduled_for_deletion'
 
     assert_displayed_in_new_tab(browser, detail_view.open_public_domain, LandingView)

--- a/testsuite/tests/ui/webhooks/test_webhooks_account.py
+++ b/testsuite/tests/ui/webhooks/test_webhooks_account.py
@@ -5,7 +5,7 @@ import xml.etree.ElementTree as Et
 
 import pytest
 
-from testsuite import rawobj
+from testsuite import rawobj, resilient
 from testsuite.ui.views.admin.audience.account import UsageRulesView, AccountEditView, AccountsDetailView
 from testsuite.ui.views.admin.audience.account_plan import NewAccountPlanView, AccountPlansView
 from testsuite.ui.views.admin.settings.webhooks import WebhooksView
@@ -86,7 +86,7 @@ def test_account_plan_changed(account, threescale, login, navigator, requestbin,
     name = blame(request, "app_plan")
     plan_view = navigator.navigate(NewAccountPlanView)
     plan_view.create(name, name)
-    plan = threescale.account_plans.read_by_name(name)
+    plan = resilient.resource_read_by_name(threescale.account_plans, name)
     plan_view = navigator.navigate(AccountPlansView)
     plan_view.publish(plan.entity_id)
     account_view = navigator.navigate(AccountsDetailView, account=account)

--- a/testsuite/tests/ui/webhooks/test_webhooks_application.py
+++ b/testsuite/tests/ui/webhooks/test_webhooks_application.py
@@ -6,7 +6,7 @@ import xml.etree.ElementTree as Et
 
 import pytest
 
-from testsuite import rawobj
+from testsuite import rawobj, resilient
 from testsuite.ui.views.admin.audience.application import ApplicationEditView, ApplicationDetailView
 from testsuite.ui.views.admin.settings.webhooks import WebhooksView
 from testsuite.utils import blame
@@ -139,7 +139,7 @@ def test_user_key_updated(custom_app, navigator, login, requestbin, account, ser
     application = custom_app()
     app = navigator.navigate(ApplicationDetailView, application=application, product=service)
     app.regenerate_user_key()
-    application = account.applications.read_by_name(application.entity_name)
+    application = resilient.resource_read_by_name(account.applications, application.entity_name)
 
     webhook = requestbin.get_webhook("user_key_updated", str(application.entity_id))
     assert webhook is not None

--- a/testsuite/tests/ui/webhooks/test_webhooks_keys.py
+++ b/testsuite/tests/ui/webhooks/test_webhooks_keys.py
@@ -6,6 +6,8 @@ import xml.etree.ElementTree as Et
 
 import pytest
 from threescale_api.resources import Service
+
+from testsuite import resilient
 from testsuite.ui.views.admin.audience.application import ApplicationDetailView
 from testsuite.ui.views.admin.settings.webhooks import WebhooksView
 
@@ -67,7 +69,7 @@ def test_user_key_regenerate(login, service, application, account, requestbin, n
 
     app = navigator.navigate(ApplicationDetailView, application=application, product=service)
     app.regenerate_user_key()
-    application = account.applications.read_by_name(application.entity_name)
+    application = resilient.resource_read_by_name(account.applications, application.entity_name)
 
     webhook = requestbin.get_webhook("key_updated", str(application.entity_id))
     assert webhook is not None


### PR DESCRIPTION
Added default backoff to UI test when the resource is created in UI but may not be processed by server before API call