### PR TITLE
Add blame to unique_invoice_id test

### DIFF
--- a/testsuite/tests/system/test_unique_invoice_id.py
+++ b/testsuite/tests/system/test_unique_invoice_id.py
@@ -8,6 +8,7 @@ from datetime import date, timedelta
 import pytest
 from threescale_api.resources import InvoiceState, Account, ApplicationPlan
 from testsuite import rawobj
+from testsuite.utils import blame, blame_desc
 
 pytestmark = [
     pytest.mark.nopersistence,
@@ -18,23 +19,24 @@ ACCOUNTS_COUNT = 10
 
 
 @pytest.fixture()
-def paid_app_plan(service, custom_app_plan) -> ApplicationPlan:
+def paid_app_plan(request, service, custom_app_plan) -> ApplicationPlan:
     """Application plan on default service with some setup fee"""
-    return custom_app_plan(rawobj.ApplicationPlan("paidplan", setup_fee=100), service=service)
+    return custom_app_plan(rawobj.ApplicationPlan(blame(request, "inv-paid"), setup_fee=100), service=service)
 
 
 @pytest.fixture()
-def custom_paid_account(paid_app_plan, custom_account, custom_application, account_password):
+def custom_paid_account(request, paid_app_plan, custom_account, custom_application, account_password):
     """Returns function for custom account creation"""
     def _custom_paid_account(num: int) -> Account:
         """
         Makes number of accounts with applications that use paid app plan.
         :param num: Number of accounts to create
         """
-        acc_params = rawobj.AccountUser(f"test-{num}", f"{num}@anything.invalid", account_password)
-        acc_params.update(org_name=f"test-{num}")
+        name = blame(request, f"inv-{num}")
+        acc_params = rawobj.AccountUser(name, f"{name}@anything.invalid", account_password)
+        acc_params.update(org_name=name)
         account = custom_account(acc_params)
-        custom_application(rawobj.Application(f"app-{num})", paid_app_plan, "desc"), account=account)
+        custom_application(rawobj.Application(name, paid_app_plan, blame_desc(request, "desc")), account=account)
         return account
     return _custom_paid_account
 
@@ -43,27 +45,28 @@ def custom_paid_account(paid_app_plan, custom_account, custom_application, accou
 def create_invoice(custom_paid_account, master_threescale, threescale,
                    provider_account, request):
     """Creates ACCOUNTS_COUNT accounts and for each account charge invoice with master_api"""
+    next_day = (date.today() + timedelta(days=1)).isoformat()
+    accounts = []
+    for i in range(ACCOUNTS_COUNT):
+        account = custom_paid_account(i)
+        accounts.append(account)
+        master_threescale.tenants.trigger_billing_account(provider_account, account, next_day)
+
     def clean_invoice():
-        for i in range(ACCOUNTS_COUNT):
-            acc: Account = threescale.accounts.read_by_name(f"test-{i}")
+        for acc in accounts:
             for invoice in threescale.invoices.list_by_account(acc):
                 invoice.state_update(InvoiceState.CANCELLED)
 
     request.addfinalizer(clean_invoice)
 
-    next_day = (date.today() + timedelta(days=1)).isoformat()
-
-    for i in range(ACCOUNTS_COUNT):
-        account = custom_paid_account(i)
-        master_threescale.tenants.trigger_billing_account(provider_account, account, next_day)
+    return accounts
 
 
 def test_unique_invoice(create_invoice, threescale):  # pylint: disable=unused-argument
     """For all accounts combined (ACCOUNTS_COUNT times created) check if there are no duplicate 'friendly_id'"""
     invoices = []
     invoices_by_friendly_id = set()  # duplicates gets squashed
-    for i in range(ACCOUNTS_COUNT):
-        acc: Account = threescale.accounts.read_by_name(f"test-{i}")
+    for acc in create_invoice:
         for invoice in threescale.invoices.list_by_account(acc):
             invoices.append(invoice)
             invoices_by_friendly_id.add(invoice['friendly_id'])


### PR DESCRIPTION
I changed the flow of code a bit.
`create_invoice` now returns list of accounts it created for better handling, as the names are now nondeterministic.
Maybe renaming of `create_invoice` is a good idea?
