### PR TITLE
Improve test stability

### DIFF
--- a/testsuite/resilient.py
+++ b/testsuite/resilient.py
@@ -4,7 +4,7 @@ import backoff
 
 
 @backoff.on_exception(backoff.fibo, AssertionError, max_tries=8, jitter=None)
-def stats_service_usage(threescale, service_id, metric_name, key, threshold=0):
+def analytics_list_by_service(threescale, service_id, metric_name, key, threshold=0):
     """Get usage stats for service"""
     value = threescale.analytics.list_by_service(service_id, metric_name=metric_name)[key]
     assert value >= threshold

--- a/testsuite/tests/apicast/apiap/test_backend_routing.py
+++ b/testsuite/tests/apicast/apiap/test_backend_routing.py
@@ -203,7 +203,7 @@ def test(request, backend_usages, application, client, setup, expect_ok, expect_
         response = client.get(path)
         assert response.status_code == 200, f"For path {path} expected status_code 200"
 
-        hits_after = resilient.stats_service_usage(
+        hits_after = resilient.analytics_list_by_service(
             application.threescale_client, application["service_id"], "hits", "total", hits_before+1)
 
         assert hits_before + 1 == hits_after, f"For path {path} expected hits to be increased by 1"

--- a/testsuite/tests/apicast/policy/custom_metric/test_custom_metric_policy_parametrized.py
+++ b/testsuite/tests/apicast/policy/custom_metric/test_custom_metric_policy_parametrized.py
@@ -96,7 +96,7 @@ def test_custom_policy(application, threescale, config, client):
         for i, metric in enumerate(metrics):
             threshold = hits_before[i] + increments[i]
             hits_after.append(
-                resilient.stats_service_usage(threescale, application["service_id"], metric, "total", threshold))
+                resilient.analytics_list_by_service(threescale, application["service_id"], metric, "total", threshold))
 
         for i, increment in enumerate(increments):
             assert hits_after[i] - hits_before[i] == increment

--- a/testsuite/tests/apicast/policy/soap/test_soap_policy.py
+++ b/testsuite/tests/apicast/policy/soap/test_soap_policy.py
@@ -3,6 +3,7 @@ Rewrite spec/functional_specs/policies/soap/soap_policy_spec.rb
 """
 import pytest
 from testsuite import rawobj
+from testsuite import resilient
 
 
 @pytest.fixture(scope="module")
@@ -19,7 +20,8 @@ def test_soap_policy_action(api_client, application):
     analytics = application.threescale_client.analytics
     usage_before = analytics.list_by_service(application["service_id"], metric_name="hits")["total"]
     api_client().get("/get", headers={"Soapaction": "soap_policy_action"})
-    usage_after = analytics.list_by_service(application["service_id"], metric_name="hits")["total"]
+    usage_after = resilient.analytics_list_by_service(
+        application.threescale_client, application["service_id"], "hits", "total", usage_before+1)
     assert usage_after == usage_before + 4
 
 
@@ -28,7 +30,8 @@ def test_soap_policy_ctype(api_client, application):
     analytics = application.threescale_client.analytics
     usage_before = analytics.list_by_service(application["service_id"], metric_name="hits")["total"]
     api_client().get("/get", headers={"Content-Type": "application/soap+xml;action=soap_policy_ctype"})
-    usage_after = analytics.list_by_service(application["service_id"], metric_name="hits")["total"]
+    usage_after = resilient.analytics_list_by_service(
+        application.threescale_client, application["service_id"], "hits", "total", usage_before+1)
     assert usage_after == usage_before + 6
 
 
@@ -38,7 +41,8 @@ def test_soap_policy_action_ctype(api_client, application):
     usage_before = analytics.list_by_service(application["service_id"], metric_name="hits")["total"]
     api_client().get("/get", headers={"Soapaction": "soap_policy_action",
                                       "Content-Type": "application/soap+xml;action=soap_policy_ctype"})
-    usage_after = analytics.list_by_service(application["service_id"], metric_name="hits")["total"]
+    usage_after = resilient.analytics_list_by_service(
+        application.threescale_client, application["service_id"], "hits", "total", usage_before+1)
     assert usage_after == usage_before + 6
 
 
@@ -47,5 +51,6 @@ def test_soap_policy_nothing(api_client, application):
     analytics = application.threescale_client.analytics
     usage_before = analytics.list_by_service(application["service_id"], metric_name="hits")["total"]
     api_client().get("/get")
-    usage_after = analytics.list_by_service(application["service_id"], metric_name="hits")["total"]
+    usage_after = resilient.analytics_list_by_service(
+        application.threescale_client, application["service_id"], "hits", "total", usage_before+1)
     assert usage_after == usage_before + 1

--- a/testsuite/tests/apicast/policy/test_upstream_url_rewriting_policy.py
+++ b/testsuite/tests/apicast/policy/test_upstream_url_rewriting_policy.py
@@ -56,6 +56,6 @@ def test_url_rewriting_policy_v2(api_client, application, private_base_url):
     request = EchoedRequest.create(response)
     assert request.headers["Host"] == parsed_url.hostname
 
-    hits = resilient.stats_service_usage(
+    hits = resilient.analytics_list_by_service(
         application.threescale_client, application["service_id"], "hits", "total", old_usage+1)
     assert hits == old_usage + 1

--- a/testsuite/tests/system/analytics/test_analytics.py
+++ b/testsuite/tests/system/analytics/test_analytics.py
@@ -48,7 +48,7 @@ def test_hits_service(application, api_client, app2):
     for _ in range(requests_app2):
         assert client2.get("/get").status_code == 200
 
-    metrics_service = resilient.stats_service_usage(
+    metrics_service = resilient.analytics_list_by_service(
         app2.threescale_client, app2["service_id"], "hits", "total", requests_app+requests_app2)
     assert metrics_service == prev_service_hits + requests_app + requests_app2
 

--- a/testsuite/tests/system/mapping/test_mapping_rules_matching_order_multiple_backends.py
+++ b/testsuite/tests/system/mapping/test_mapping_rules_matching_order_multiple_backends.py
@@ -12,6 +12,7 @@ the request matching that mapping rule is not evaluated by other mapping rules.
 import pytest
 
 from testsuite import rawobj
+from testsuite import resilient
 
 pytestmark = [pytest.mark.nopersistence]
 
@@ -173,6 +174,7 @@ def test(application, client, backend_usages, backends, expect_ok):
         response = client.get(path)
         assert response.status_code == 200, f"For path {path} expected status_code 200"
 
-        hits_after = hits(application)
+        hits_after = resilient.analytics_list_by_service(
+            application.threescale_client, application["service_id"], "hits", "total")
         assert hits_after == hits_before + expected_hits_diff, \
             f"For {path} expected different number of hits"

--- a/testsuite/tests/system/test_unique_invoice_id.py
+++ b/testsuite/tests/system/test_unique_invoice_id.py
@@ -5,6 +5,7 @@ Test automatically created invoices will not have duplicate 'friendly_id'
 For testing this issue, we don't need to use UI, as all can be done trough API
 """
 from datetime import date, timedelta
+import backoff
 import pytest
 from threescale_api.resources import InvoiceState, Account, ApplicationPlan
 from testsuite import rawobj
@@ -58,6 +59,8 @@ def create_invoice(custom_paid_account, master_threescale, threescale,
         master_threescale.tenants.trigger_billing_account(provider_account, account, next_day)
 
 
+# this is flaky little bit, not all the invoices seem triggered instantly
+@backoff.on_exception(backoff.fibo, AssertionError, max_tries=8, jitter=None)
 def test_unique_invoice(create_invoice, threescale):  # pylint: disable=unused-argument
     """For all accounts combined (ACCOUNTS_COUNT times created) check if there are no duplicate 'friendly_id'"""
     invoices = []


### PR DESCRIPTION
- Known name for resilient analytics.list_by_service
- Use resilient call when appropriate
- backoff on test_unique_invoice to ensure all invoices triggered
