### PR TITLE
Fix context issue with get_logs() method

### DIFF
--- a/testsuite/openshift/client.py
+++ b/testsuite/openshift/client.py
@@ -248,10 +248,7 @@ class OpenShiftClient:
         """
         with ExitStack() as stack:
             self.prepare_context(stack)
-            if labels:
-                selector = oc.selector(resource, labels=labels)
-            else:
-                selector = oc.selector(resource)
+            selector = oc.selector(resource, labels=labels)
 
             if narrow_function:
                 selector = selector.narrow(narrow_function)

--- a/testsuite/openshift/deployments.py
+++ b/testsuite/openshift/deployments.py
@@ -129,10 +129,12 @@ class Deployment(ABC):
             d_with_timezone = since_time.replace(tzinfo=timezone.utc)
             time = d_with_timezone.isoformat()
             cmd_args.append(f"--since-time={time}")
-        pod = self.get_pods()
-        # For some reason, the logs can return empty string sometimes, this seems to mitigate it
-        pod.objects()
-        logs = pod.logs(tail, cmd_args=cmd_args)
+        with ExitStack() as stack:
+            self.openshift.prepare_context(stack)
+            pod = self.get_pods()
+            # For some reason, the logs can return empty string sometimes, this seems to mitigate it
+            pod.objects()
+            logs = pod.logs(tail, cmd_args=cmd_args)
         return "".join(logs.values())
 
     def patch(self, patch, patch_type: str = None, timeout=90):


### PR DESCRIPTION
Experimental fix, I suspect the context is still needed even when working with the result outside of the get_pods(select_resource) method.