### PR TITLE
Add lazy loading for staging OperatorApicast

### DIFF
--- a/testsuite/gateways/apicast/operator.py
+++ b/testsuite/gateways/apicast/operator.py
@@ -150,6 +150,7 @@ class OperatorApicast(OpenshiftApicast):
         if self.staging:
             apicast["deploymentEnvironment"] = "staging"
             apicast["cacheConfigurationSeconds"] = 0
+            apicast["configurationLoadMode"] = "lazy"
         else:
             apicast["deploymentEnvironment"] = "production"
             apicast["cacheConfigurationSeconds"] = 300


### PR DESCRIPTION
This change brings it close to what TemplateApicast deployment looks like but doesn't have any effect on tests as cacheConfigurationSeconds: 0 has the same effect.