### PR TITLE
Fix Apicast Operator secret cleanup

### DIFF
--- a/testsuite/gateways/apicast/__init__.py
+++ b/testsuite/gateways/apicast/__init__.py
@@ -104,7 +104,7 @@ class OpenshiftApicast(AbstractApicast, ABC):
                 del self.openshift.routes[route]
 
         for kind, name in self._to_delete:
-            self.openshift.delete(kind, name)
+            self.openshift.delete(kind, name, ignore_not_found=True)
 
     def create(self):
         super().create()

--- a/testsuite/gateways/apicast/operator.py
+++ b/testsuite/gateways/apicast/operator.py
@@ -140,10 +140,15 @@ class OperatorApicast(OpenshiftApicast):
         self.deployment.rollout()
 
     def create(self):
+        # Create secret with Provider URL credentials
+        self.openshift.secrets.create(self.name, string_data={
+            "AdminPortalURL": self.portal_endpoint
+        })
+        self._to_delete.append(("secret", self.name))
+
         apicast = APIcast.create_instance(
             openshift=self.openshift,
             name=self.name,
-            provider_url=self.portal_endpoint
         )
         apicast["logLevel"] = "info"
         apicast["openSSLPeerVerificationEnabled"] = False

--- a/testsuite/openshift/client.py
+++ b/testsuite/openshift/client.py
@@ -157,14 +157,15 @@ class OpenShiftClient:
             self.prepare_context(stack)
             oc.apply(resource)
 
-    def delete(self, resource_type: str, name: str, force: bool = False):
+    def delete(self, resource_type: str, name: str, force: bool = False, ignore_not_found=False):
         """Delete a resource.
         Args:
             :param resource_type: The resource type to be deleted. Ex.: service, route, deploymentconfig
             :param name: The resource name
             :param force: Pass --force to oc delete
+            :param ignore_not_found: If false, it will fail if the object doesn't exist
         """
-        args = []
+        args = [f"--ignore-not-found={ignore_not_found}"]
         if force:
             args.append("-f")
         self.do_action("delete", [resource_type, name, args])

--- a/testsuite/openshift/crd/apicast.py
+++ b/testsuite/openshift/crd/apicast.py
@@ -8,20 +8,14 @@ class APIcast(APIObject):
     """APIcast CRD object supporting modifying all attributes"""
 
     @classmethod
-    def create_instance(cls, openshift: OpenShiftClient, name, provider_url, labels=None):
+    def create_instance(cls, openshift: OpenShiftClient, name, labels=None):
         """
         Creates new barebone instance, that can be customized with additional attributes before committing.
         :param openshift:       Openshift object instance
         :param name:            Name of the resource
-        :param provider_url:    URL to the provider admin portal
         :param labels:          Labels
         :return: Uncommited APIcast instance
         """
-
-        # Create secret with Provider URL credentials credentials
-        openshift.secrets.create(name, string_data={
-            "AdminPortalURL": provider_url
-        })
 
         model = {
             "apiVersion": "apps.3scale.net/v1alpha1",


### PR DESCRIPTION
- Currently, OperatorApicast doesn't cleanup secrets it created after test run
   - Previously, it was cleaned by the operator itself as it took ownership of that secret, but the behaviour changes
- Move responsibility for managing secret back from APIcast object to OperatorAPIcast
- Don't throw an error if the deletion fails
   - The previous version of Operator will still delete the secret so it might fail on previous versions.