### PR TITLE
Fix incorrect import of KeycloakGetError

### DIFF
--- a/testsuite/tests/system/oidc/test_openid_rhsso_will_delete_client.py
+++ b/testsuite/tests/system/oidc/test_openid_rhsso_will_delete_client.py
@@ -4,7 +4,7 @@ Rewrite of spec/functional_specs/auth/rhsso/open_id_rhsso_will_delete_client_spe
 
 import backoff
 import pytest
-from keycloak import KeycloakGetError
+from keycloak.exceptions import KeycloakGetError
 
 from testsuite import rawobj
 from testsuite.rhsso import OIDCClientAuthHook

--- a/testsuite/tests/system/oidc/test_openid_rhsso_zync_sync.py
+++ b/testsuite/tests/system/oidc/test_openid_rhsso_zync_sync.py
@@ -3,7 +3,7 @@ Rewrite of the spec/functional_specs/auth/rhsso/open_id_rhsso_zync_sync_spec.rb
 """
 import backoff
 import pytest
-from keycloak import KeycloakGetError
+from keycloak.exceptions import KeycloakGetError
 
 from testsuite.rhsso import OIDCClientAuthHook
 


### PR DESCRIPTION
This was changes in recent release of `python-keycloak` (May 19)