### PR TITLE
Fix for _whoami() function in testsuite/utils.py

### DIFF
--- a/testsuite/utils.py
+++ b/testsuite/utils.py
@@ -38,7 +38,12 @@ def _whoami():
     # want to catch broad exception and fallback at any circumstance
     # pylint: disable=broad-except
     except Exception:
-        return str(os.getuid())
+        try:
+            # this expression is an equivalent of os.getlogin() for some environments
+            return pwd.getpwuid(os.getuid()).pw_name
+        # pylint: disable=broad-except
+        except Exception:
+            return str(os.getuid())
 
 
 def blame(request: 'FixtureRequest', name: str, tail: int = 3) -> str:


### PR DESCRIPTION
In some environments os.getlogin() returns an error, for example in a shell
inside Docker container, so it was replaced by os.getuid() and user name
resolution.