### PR TITLE
Fix has_apicast_operator check

### DIFF
--- a/testsuite/openshift/client.py
+++ b/testsuite/openshift/client.py
@@ -240,11 +240,11 @@ class OpenShiftClient:
     def has_apicast_operator(self):
         """True if apicast operator is found in local namespace or in openshift-operators"""
         try:
-            return self.apicast_operator_subscription is not None
+            return self.apicast_operator_subscription.object() is not None
         except oc.OpenShiftPythonException:
             ocp = OpenShiftClient("openshift-operators", self.server_url, self.token)
             try:
-                return ocp.apicast_operator_subscription is not None
+                return ocp.apicast_operator_subscription.object() is not None
             except oc.OpenShiftPythonException:
                 return False
 


### PR DESCRIPTION
openshift "always" returns something, object should be checked after
they are mined from openshift reply.
