### PR TITLE
Update umask in the container - 'w' also for group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,9 @@ ENV junit=yes
 ENV resultsdir=$_resultsdir
 ENV PYTEST_ADDOPTS="-o cache_dir=$_resultsdir/.pytest-cache"
 
-RUN make mostlyclean pipenv && \
-	rm -Rf $HOME/.cache/*
+RUN echo umask 002 >>$HOME/.bashrc \
+	&& make mostlyclean pipenv \
+	&& rm -Rf $HOME/.cache/*
 
 ENTRYPOINT [ "make" ]
 CMD [ "smoke" ]


### PR DESCRIPTION
This is handy especially (but not only) with podman in use when root
groupid inside of container is mapped to groupid of the user outside of
the container (while userid can be different/random) to ensure correct
access for the user.
