### PR TITLE
Change report header structure

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -55,6 +55,7 @@ stripe= "*"
 braintree = "*"
 pillow = "*"
 pytest-persistence = "*"
+pytest-metadata = "*"
 
 [requires]
 python_version = "3"


### PR DESCRIPTION
Simplify report header rendering. Add more to junit testsuite
properties. Use dynaconf env name to report values. Use pytest-metadata.
Print also env settings values.
