### PR TITLE
Introduce custom markers to skip tests based on version

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,10 @@ markers =
 	required_capabilities(capability1, capability2, ...): List of capabilities that are required for running this test
 	issue: Reference to covered issue
 	nopersistence: Tests incompatible with persistence plugin
+	require_version: Run on this or later version
+	before_version: Run on versions below this
+	require_apicast_operator_version: Run on this or later version
+	before_apicast_operator_version: Run on versions below this
 filterwarnings =
     ignore: WARNING the new order is not taken into account:UserWarning
     ignore::urllib3.exceptions.InsecureRequestWarning

--- a/testsuite/tests/apicast/apiap/routing/test_routing.py
+++ b/testsuite/tests/apicast/apiap/routing/test_routing.py
@@ -4,16 +4,14 @@ Test that request to product with specific paths to backends will be routed to c
 import pytest
 import pytest_cases
 from pytest_cases import parametrize_with_cases
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 from testsuite import rawobj
 from testsuite.echoed_request import EchoedRequest
 from testsuite.tests.apicast.apiap.routing import routing_cases
 from testsuite.utils import blame
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.8.2')"),
+    pytest.mark.require_version("2.8.2"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-4937")]
 
 
@@ -65,10 +63,10 @@ def client(staging_gateway, application):
 
 
 @pytest_cases.parametrize("append_slash", [
-    pytest.param(True, id="2.10_legacy", marks=[pytest.mark.skipif("TESTED_VERSION >= Version('2.11')")]),
+    pytest.param(True, id="2.10_legacy", marks=[pytest.mark.before_version("2.11")]),
     pytest.param(False, id="",
                  marks=[pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-7146"),
-                        pytest.mark.skipif("TESTED_VERSION < Version('2.11')")]),
+                        pytest.mark.require_version("2.11")]),
 ])
 def test(client, paths, append_slash):
     """

--- a/testsuite/tests/apicast/apiap/special_chars/test_windows_1252.py
+++ b/testsuite/tests/apicast/apiap/special_chars/test_windows_1252.py
@@ -5,13 +5,11 @@ from urllib.parse import urlparse
 
 import pytest
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 from testsuite.echoed_request import EchoedRequest
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 
 pytestmark = [
     pytest.mark.xfail,
-    pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+    pytest.mark.require_version("2.11"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6834")]
 
 HEX_CHARS = "0123456789ABCDEF"

--- a/testsuite/tests/apicast/apiap/test_apiap_routing_to_backend.py
+++ b/testsuite/tests/apicast/apiap/test_apiap_routing_to_backend.py
@@ -4,12 +4,11 @@ Test if APIAP routing only match paths that contain whole routing path
 from urllib.parse import urlparse
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.echoed_request import EchoedRequest
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.8.1')"),
+    pytest.mark.require_version("2.8.1"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-4904")]
 
 

--- a/testsuite/tests/apicast/apiap/test_apiap_routing_with_backend_metrics.py
+++ b/testsuite/tests/apicast/apiap/test_apiap_routing_with_backend_metrics.py
@@ -2,13 +2,12 @@
 Test apiap routing combined with metrics counting
 """
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 
 # case[N] fixtures create tests that have to be executed in specific order
 pytestmark = [
     pytest.mark.disruptive,
-    pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
+    pytest.mark.require_version("2.9"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-3623")]
 
 

--- a/testsuite/tests/apicast/apiap/test_apiap_routing_with_product_mapping.py
+++ b/testsuite/tests/apicast/apiap/test_apiap_routing_with_product_mapping.py
@@ -2,11 +2,10 @@
 Test if APIAP routing only match paths that start with the routing path of the backend
 """
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.8.1')"),
+    pytest.mark.require_version("2.8.1"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-4736")]
 
 

--- a/testsuite/tests/apicast/apiap/test_proxy_config.py
+++ b/testsuite/tests/apicast/apiap/test_proxy_config.py
@@ -2,14 +2,12 @@
 Update api_backend on service without backend configured
 """
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 import pytest
 
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
+    pytest.mark.require_version("2.9"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-3626")]
 
 

--- a/testsuite/tests/apicast/apiap/test_public_base_url.py
+++ b/testsuite/tests/apicast/apiap/test_public_base_url.py
@@ -1,13 +1,11 @@
 """Test for Public Base URLs as localhost"""
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 from threescale_api.errors import ApiClientError
 
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 
 pytestmark = [
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-7149"),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.12')")
+    pytest.mark.require_version("2.12")
 ]
 
 

--- a/testsuite/tests/apicast/parameters/apicast_path_routing/test_apicast_path_routing_query.py
+++ b/testsuite/tests/apicast/parameters/apicast_path_routing/test_apicast_path_routing_query.py
@@ -3,14 +3,13 @@ Test that path based routing does match args
 """
 import pytest
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.echoed_request import EchoedRequest
 from testsuite.capabilities import Capability
 
 pytestmark = [pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT),
               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-5149"),
-              pytest.mark.skipif("TESTED_VERSION < Version('2.9')")]
+              pytest.mark.require_version("2.9")]
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/apicast_path_routing/test_mapping_rule_wrongly_matched.py
+++ b/testsuite/tests/apicast/parameters/apicast_path_routing/test_mapping_rule_wrongly_matched.py
@@ -4,12 +4,10 @@ APICAST_PATH_ROUTING is in use
 """
 import pytest
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 from testsuite import rawobj
 from testsuite.capabilities import Capability
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
+pytestmark = [pytest.mark.require_version("2.9"),
               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-4152"),
               pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT)]
 

--- a/testsuite/tests/apicast/parameters/filter_by_url/test_oidc_timeout_err_filter_by_url.py
+++ b/testsuite/tests/apicast/parameters/filter_by_url/test_oidc_timeout_err_filter_by_url.py
@@ -11,7 +11,6 @@
 """
 from time import time
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 import pytest
 from threescale_api.resources import Service
 
@@ -20,11 +19,10 @@ from testsuite.gateways import gateway
 from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 from testsuite.gateways.apicast.template import TemplateApicast
 from testsuite.utils import blame
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 
 pytestmark = [
     pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+    pytest.mark.require_version("2.11"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6139")]
 
 

--- a/testsuite/tests/apicast/parameters/http_proxy/large_data/test_http_proxy_large_data.py
+++ b/testsuite/tests/apicast/parameters/http_proxy/large_data/test_http_proxy_large_data.py
@@ -3,15 +3,14 @@ Test large data in post request when using http and https proxies
 """
 from urllib.parse import urlparse
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 import pytest
 
-from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.echoed_request import EchoedRequest
 from testsuite.capabilities import Capability
 from testsuite.utils import random_string
 
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
+pytestmark = [pytest.mark.require_version("2.9"),
               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-3863"),
               pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT)]
 

--- a/testsuite/tests/apicast/parameters/http_proxy/large_data/test_http_proxy_large_data_apiap.py
+++ b/testsuite/tests/apicast/parameters/http_proxy/large_data/test_http_proxy_large_data_apiap.py
@@ -4,15 +4,13 @@ This test will cover APIAP feature
 """
 from urllib.parse import urlparse
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 import pytest
 
-from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.echoed_request import EchoedRequest
 from testsuite.capabilities import Capability
 from testsuite.tests.toolbox.test_backend import random_string
 
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
+pytestmark = [pytest.mark.require_version("2.9"),
               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-3863"),
               pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT)]
 

--- a/testsuite/tests/apicast/parameters/policies/test_content_caching_policy_parameters.py
+++ b/testsuite/tests/apicast/parameters/policies/test_content_caching_policy_parameters.py
@@ -4,17 +4,16 @@ Test that content caching policy is working correctly with env:
     - APICAST_CACHE_MAX_TIME = max time that content can be cached
 """
 import time
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 import pytest
 
-from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.echoed_request import EchoedRequest
 from testsuite.capabilities import Capability
 from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 from testsuite.utils import blame, randomize
 
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
+pytestmark = [pytest.mark.require_version("2.9"),
               pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT)]
 
 

--- a/testsuite/tests/apicast/parameters/test_date_logging.py
+++ b/testsuite/tests/apicast/parameters/test_date_logging.py
@@ -4,16 +4,15 @@ Test for logging policy with custom date format
 from datetime import datetime, timezone
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import rawobj, TESTED_VERSION, APICAST_OPERATOR_VERSION  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.capabilities import Capability
 
 pytestmark = [
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6594"),
     pytest.mark.required_capabilities(Capability.LOGS),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.12')"),
-    pytest.mark.skipif("APICAST_OPERATOR_VERSION < Version('0.6.0')")
+    pytest.mark.require_version("2.12"),
+    pytest.mark.require_apicast_operator_version("0.6.0")
 ]
 
 

--- a/testsuite/tests/apicast/policy/batcher/test_batcher_policy_mapping_rules.py
+++ b/testsuite/tests/apicast/policy/batcher/test_batcher_policy_mapping_rules.py
@@ -5,13 +5,12 @@
 from time import sleep
 import pytest
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 
 
 pytestmark = [
     pytest.mark.nopersistence,
-    pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
+    pytest.mark.require_version("2.9"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-5513")]
 
 

--- a/testsuite/tests/apicast/policy/batcher/test_batcher_policy_nonalphanum_metric.py
+++ b/testsuite/tests/apicast/policy/batcher/test_batcher_policy_nonalphanum_metric.py
@@ -5,12 +5,11 @@ character in the name
 from time import sleep
 import pytest
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.10')"),
+    pytest.mark.require_version("2.10"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-4913")]
 
 

--- a/testsuite/tests/apicast/policy/caching/combination/test_caching_batching_apicast_scale_allow_mode.py
+++ b/testsuite/tests/apicast/policy/caching/combination/test_caching_batching_apicast_scale_allow_mode.py
@@ -4,12 +4,11 @@ Test caching policy with allow mode.
 from time import sleep
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.capabilities import Capability
 
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.9.1')"),
+pytestmark = [pytest.mark.require_version("2.9.1"),
               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-5753"),
               pytest.mark.required_capabilities(Capability.SCALING)]
 BATCH_REPORT_SECONDS = 150

--- a/testsuite/tests/apicast/policy/caching/combination/test_caching_batching_resilient_mode.py
+++ b/testsuite/tests/apicast/policy/caching/combination/test_caching_batching_resilient_mode.py
@@ -3,11 +3,10 @@ Test caching policy with strict mode.
 """
 from time import sleep
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.capabilities import Capability
 
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.9.1')"),
+pytestmark = [pytest.mark.require_version("2.9.1"),
               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-5753"),
               pytest.mark.required_capabilities(Capability.SCALING)]
 BATCH_REPORT_SECONDS = 150

--- a/testsuite/tests/apicast/policy/caching/combination/test_caching_batching_strict_mode.py
+++ b/testsuite/tests/apicast/policy/caching/combination/test_caching_batching_strict_mode.py
@@ -4,12 +4,11 @@ Test caching policy with resilient mode.
 from time import sleep
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.capabilities import Capability
 
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.9.1')"),
+pytestmark = [pytest.mark.require_version("2.9.1"),
               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-5753"),
               pytest.mark.required_capabilities(Capability.SCALING)]
 BATCH_REPORT_SECONDS = 150

--- a/testsuite/tests/apicast/policy/caching/test_caching_type_change.py
+++ b/testsuite/tests/apicast/policy/caching/test_caching_type_change.py
@@ -3,14 +3,13 @@ Test caching policy policy. Changing caching type to None. Policy remains active
 https://issues.redhat.com/browse/THREESCALE-4464
 """
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.capabilities import Capability
 from testsuite.gateways import gateway
 from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 from testsuite.utils import blame
 
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+pytestmark = [pytest.mark.require_version("2.11"),
               pytest.mark.disruptive,
               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-4464")]
 

--- a/testsuite/tests/apicast/policy/content_caching/test_content_caching.py
+++ b/testsuite/tests/apicast/policy/content_caching/test_content_caching.py
@@ -4,13 +4,12 @@ Test valid content caching options
 
 import time
 import uuid
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 import pytest
 
-from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.echoed_request import EchoedRequest
 
-pytestmark = pytest.mark.skipif("TESTED_VERSION < Version('2.9')")
+pytestmark = pytest.mark.require_version("2.9")
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/policy/content_caching/test_content_caching_apiap.py
+++ b/testsuite/tests/apicast/policy/content_caching/test_content_caching_apiap.py
@@ -1,14 +1,13 @@
 """
 Test valid content caching on product with multiple backends
 """
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 import pytest
 
-from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.echoed_request import EchoedRequest
 from testsuite.utils import randomize, blame
 
-pytestmark = pytest.mark.skipif("TESTED_VERSION < Version('2.9')")
+pytestmark = pytest.mark.require_version("2.9")
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/policy/content_limits/test_payload_limits_request.py
+++ b/testsuite/tests/apicast/policy/content_limits/test_payload_limits_request.py
@@ -3,13 +3,12 @@ Testing that the request/response content limit policy limits the content-length
 request body
 """
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 from testsuite.utils import random_string
-from testsuite import rawobj, TESTED_VERSION # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.10')"),
+    pytest.mark.require_version("2.10"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-5244")]
 
 

--- a/testsuite/tests/apicast/policy/content_limits/test_payload_limits_response.py
+++ b/testsuite/tests/apicast/policy/content_limits/test_payload_limits_response.py
@@ -3,13 +3,12 @@ Testing that the request/response content limit policy limits the content-length
 response body
 """
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import rawobj, TESTED_VERSION # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 
 
 pytestmark = [pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-5244"),
-              pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+              pytest.mark.require_version("2.11"),
               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6736")]
 
 

--- a/testsuite/tests/apicast/policy/content_limits/test_payload_limits_unlimited.py
+++ b/testsuite/tests/apicast/policy/content_limits/test_payload_limits_unlimited.py
@@ -3,13 +3,12 @@ Testing that the request/response content limit policy does not limit anything w
 default value
 """
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 from testsuite.utils import random_string
-from testsuite import rawobj, TESTED_VERSION # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.10')"),
+    pytest.mark.require_version("2.10"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-5244")]
 
 

--- a/testsuite/tests/apicast/policy/cors/test_cors_multiple_origins.py
+++ b/testsuite/tests/apicast/policy/cors/test_cors_multiple_origins.py
@@ -6,13 +6,11 @@ If not, the "Access-Control-Allow-Origin" is not set.
 """
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import TESTED_VERSION # noqa # pylint: disable=unused-import
 from testsuite import rawobj
 
 pytestmark = [
-              pytest.mark.skipif("TESTED_VERSION < Version('2.10')"),
+              pytest.mark.require_version("2.10"),
               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6569"),
              ]
 

--- a/testsuite/tests/apicast/policy/custom_metric/test_custom_metric_policy_parametrized.py
+++ b/testsuite/tests/apicast/policy/custom_metric/test_custom_metric_policy_parametrized.py
@@ -5,17 +5,16 @@ metric based on the response from the upstream API
 """
 import pytest
 import pytest_cases
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 from pytest_cases import parametrize_with_cases
 
 from testsuite.tests.apicast.policy.custom_metric import config_cases
 from testsuite.utils import blame
-from testsuite import rawobj, resilient, TESTED_VERSION # noqa # pylint: disable=unused-import
+from testsuite import rawobj, resilient
 
 
 pytestmark = [
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-5098"),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.9')")]
+    pytest.mark.require_version("2.9")]
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/policy/ip_check/test_ip_check_policy_forward_ip_whitelist.py
+++ b/testsuite/tests/apicast/policy/ip_check/test_ip_check_policy_forward_ip_whitelist.py
@@ -1,11 +1,10 @@
 """
 Rewrite spec/functional_specs/policies/ip_check/ip_check_forward_whitelist_spec.rb
 """
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 import pytest
 
-from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 
 pytestmark = [pytest.mark.nopersistence]
 
@@ -31,11 +30,11 @@ def test_ip_check_policy_ip_blacklisted(api_client):
                           (["10.10.10.10"], 403),
                           pytest.param([","], 403, marks=[
                               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-7076"),
-                              pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+                              pytest.mark.require_version("2.11"),
                           ]),
                           pytest.param([",10.10.10.10"], 403, marks=[
                               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-7075"),
-                              pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+                              pytest.mark.require_version("2.11"),
                           ])])
 def test_ips_with_random_port(ip_addresses, status_code, api_client, ip4_addresses):
     """

--- a/testsuite/tests/apicast/policy/jwt_claim_check/test_jwt_claim_check_backend_routing.py
+++ b/testsuite/tests/apicast/policy/jwt_claim_check/test_jwt_claim_check_backend_routing.py
@@ -3,13 +3,11 @@ When routing policy is used together with the jwt claim check, the jwt should st
 restrict the access to the resource.
 """
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import TESTED_VERSION # noqa # pylint: disable=unused-import
 from testsuite import rawobj
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+    pytest.mark.require_version("2.11"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6410")]
 
 ERROR_MESSAGE = "Invalid JWT check"

--- a/testsuite/tests/apicast/policy/liquid_context_debug/test_debug_policy_apiap.py
+++ b/testsuite/tests/apicast/policy/liquid_context_debug/test_debug_policy_apiap.py
@@ -6,11 +6,8 @@ from urllib.parse import urlparse
 
 import pytest
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import rawobj, TESTED_VERSION # noqa # pylint: disable=unused-import
 
-
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+pytestmark = [pytest.mark.require_version("2.11"),
               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6312")]
 
 

--- a/testsuite/tests/apicast/policy/maintenance_mode/test_maintenance_mode_policy_host.py
+++ b/testsuite/tests/apicast/policy/maintenance_mode/test_maintenance_mode_policy_host.py
@@ -9,14 +9,13 @@ from typing import Tuple
 import pytest
 import pytest_cases
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.tests.apicast.policy.maintenance_mode import config_cases_host
 
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+    pytest.mark.require_version("2.11"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6552")]
 
 

--- a/testsuite/tests/apicast/policy/maintenance_mode/test_maintenance_mode_policy_path.py
+++ b/testsuite/tests/apicast/policy/maintenance_mode/test_maintenance_mode_policy_path.py
@@ -9,14 +9,13 @@ from typing import Tuple
 import pytest
 import pytest_cases
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import TESTED_VERSION, rawobj # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.tests.apicast.policy.maintenance_mode import config_cases_path
 
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+    pytest.mark.require_version("2.11"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6552")]
 
 

--- a/testsuite/tests/apicast/policy/nginx_filter/test_nginx_filter_ngnix_blocking.py
+++ b/testsuite/tests/apicast/policy/nginx_filter/test_nginx_filter_ngnix_blocking.py
@@ -6,13 +6,12 @@ The nginx filter policy should ensure that those requests will not be blocked.
 
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.utils import blame
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+    pytest.mark.require_version("2.11"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6704")]
 
 

--- a/testsuite/tests/apicast/policy/nginx_filter/test_nginx_filter_strip_if_match.py
+++ b/testsuite/tests/apicast/policy/nginx_filter/test_nginx_filter_strip_if_match.py
@@ -4,14 +4,13 @@ or strip the header just for the nginx evaluation, but still send it to the upst
 """
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.capabilities import Capability
 from testsuite.echoed_request import EchoedRequest
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+    pytest.mark.require_version("2.11"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6704"),
     pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT)
 ]

--- a/testsuite/tests/apicast/policy/rate_limit_headers/test_rate_limit_headers.py
+++ b/testsuite/tests/apicast/policy/rate_limit_headers/test_rate_limit_headers.py
@@ -5,20 +5,18 @@ Tests that:
  - the policy should work also on backend metrics
  - the combination of backend and service metrics should make no problem
 """
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 import pytest
 import pytest_cases
 from pytest_cases import fixture_ref
 
 from testsuite.utils import blame, wait_interval
 from testsuite import rawobj
-from testsuite import TESTED_VERSION # noqa # pylint: disable=unused-import
 
 
 # rate-limit have been always unstable, likely because of overhead in staging apicast?
 pytestmark = [
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-3795"),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
+    pytest.mark.require_version("2.9"),
     pytest.mark.flaky]
 
 

--- a/testsuite/tests/apicast/policy/rate_limit_headers/test_rate_limit_headers_multiple_limits.py
+++ b/testsuite/tests/apicast/policy/rate_limit_headers/test_rate_limit_headers_multiple_limits.py
@@ -2,17 +2,15 @@
 Tests that when an app plan has two limits with different time frame, the RateLimit information for
 the currently more constrained limit are sent.
 """
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 import pytest
 from testsuite.utils import blame, wait_interval, wait_until_next_minute, wait_interval_hour
 from testsuite import rawobj
-from testsuite import TESTED_VERSION # noqa # pylint: disable=unused-import
 
 
 # rate-limit have been always unstable, likely because of overhead in staging apicast?
 pytestmark = [
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-3795"),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
+    pytest.mark.require_version("2.9"),
     pytest.mark.flaky]
 
 

--- a/testsuite/tests/apicast/policy/rate_limit_headers/test_rate_limit_headers_no_limit.py
+++ b/testsuite/tests/apicast/policy/rate_limit_headers/test_rate_limit_headers_no_limit.py
@@ -1,16 +1,14 @@
 """
 When no limit is specified, the RateLimit headers should not be contained in the response
 """
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 import pytest
 from testsuite.utils import blame
 from testsuite import rawobj
-from testsuite import TESTED_VERSION # noqa # pylint: disable=unused-import
 
 
 # rate-limit have been always unstable, likely because of overhead in staging apicast?
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
+    pytest.mark.require_version("2.9"),
     pytest.mark.flaky]
 
 

--- a/testsuite/tests/apicast/policy/rate_limit_headers/test_rate_limit_with_batcher_policy.py
+++ b/testsuite/tests/apicast/policy/rate_limit_headers/test_rate_limit_with_batcher_policy.py
@@ -3,17 +3,15 @@ Tests that the combination with the batcher policy works as supposed
 """
 
 import time
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 import pytest
 from testsuite.utils import blame, wait_interval
 from testsuite import rawobj
-from testsuite import TESTED_VERSION # noqa # pylint: disable=unused-import
 
 
 # rate-limit have been always unstable, likely because of overhead in staging apicast?
 pytestmark = [
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-3795"),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
+    pytest.mark.require_version("2.9"),
     pytest.mark.flaky]
 
 

--- a/testsuite/tests/apicast/policy/routing/test_routing_policy_catch_all.py
+++ b/testsuite/tests/apicast/policy/routing/test_routing_policy_catch_all.py
@@ -5,12 +5,11 @@ the requests to a correct backend.
 from urllib.parse import urlparse
 import pytest
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.echoed_request import EchoedRequest
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+    pytest.mark.require_version("2.11"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6415")]
 
 

--- a/testsuite/tests/apicast/policy/statuscode_overwrite/test_statuscode_overwrite_payload_too_large_before.py
+++ b/testsuite/tests/apicast/policy/statuscode_overwrite/test_statuscode_overwrite_payload_too_large_before.py
@@ -6,10 +6,9 @@ on the response code produced by the second policy.
 """
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION, rawobj # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+pytestmark = [pytest.mark.require_version("2.11"),
               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6255")]
 
 

--- a/testsuite/tests/apicast/policy/statuscode_overwrite/test_statuscode_overwrite_payoad_too_large_after.py
+++ b/testsuite/tests/apicast/policy/statuscode_overwrite/test_statuscode_overwrite_payoad_too_large_after.py
@@ -6,10 +6,9 @@ affect the response code of the other policy.
 """
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION, rawobj # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+pytestmark = [pytest.mark.require_version("2.11"),
               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6255")]
 
 

--- a/testsuite/tests/apicast/policy/statuscode_overwrite/test_statuscode_overwrite_policy.py
+++ b/testsuite/tests/apicast/policy/statuscode_overwrite/test_statuscode_overwrite_policy.py
@@ -4,10 +4,9 @@ certain response codes from backend, the response codes are overwritten.
 """
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION, rawobj # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+pytestmark = [pytest.mark.require_version("2.11"),
               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6255")]
 
 

--- a/testsuite/tests/apicast/policy/test_upstream_connection.py
+++ b/testsuite/tests/apicast/policy/test_upstream_connection.py
@@ -1,12 +1,11 @@
 "testing proper function of upstream test connection"
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 import pytest
 
-from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 
-pytestmark = pytest.mark.skipif("TESTED_VERSION < Version('2.6')")
+pytestmark = pytest.mark.require_version("2.6")
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/policy/tls/test_tls_backend_routing.py
+++ b/testsuite/tests/apicast/policy/tls/test_tls_backend_routing.py
@@ -2,9 +2,8 @@
 
 import pytest
 import requests
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.capabilities import Capability
 from testsuite.echoed_request import EchoedRequest
 from testsuite.tests.apicast.policy.tls import embedded
@@ -12,7 +11,7 @@ from testsuite.tests.apicast.policy.tls import embedded
 pytestmark = [
     pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-8007"),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.12')")
+    pytest.mark.require_version("2.12")
 ]
 
 

--- a/testsuite/tests/apicast/policy/tls/test_tls_path_routing.py
+++ b/testsuite/tests/apicast/policy/tls/test_tls_path_routing.py
@@ -4,9 +4,8 @@ from urllib.parse import urlsplit
 
 import pytest
 import requests
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import rawobj, TESTED_VERSION, APICAST_OPERATOR_VERSION  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.capabilities import Capability
 from testsuite.echoed_request import EchoedRequest
 from testsuite.tests.apicast.policy.tls import embedded
@@ -16,8 +15,8 @@ pytestmark = [
     pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-8000"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-8252"),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.12')"),
-    pytest.mark.skipif("APICAST_OPERATOR_VERSION < Version('0.6.0')")
+    pytest.mark.require_version("2.12"),
+    pytest.mark.require_apicast_operator_version("0.6.0")
 ]
 
 

--- a/testsuite/tests/apicast/policy/tls/tls_upstream/mtls_upstream_cert_validation/test_upstream_mtls_policy_upstream_cert_validation.py
+++ b/testsuite/tests/apicast/policy/tls/tls_upstream/mtls_upstream_cert_validation/test_upstream_mtls_policy_upstream_cert_validation.py
@@ -11,17 +11,16 @@ from urllib.parse import urlparse
 
 import pytest
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 from testsuite.capabilities import Capability
 from testsuite.openshift.objects import Routes
 from testsuite.tests.apicast.policy.tls import embedded
-from testsuite import TESTED_VERSION, rawobj # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.utils import blame
 
 pytestmark = [
     pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+    pytest.mark.require_version("2.11"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-7099")
 ]
 

--- a/testsuite/tests/apicast/policy/tls/tls_upstream/tls_passthrough_connection_reuse/test_connection_reuse.py
+++ b/testsuite/tests/apicast/policy/tls/tls_upstream/tls_passthrough_connection_reuse/test_connection_reuse.py
@@ -7,13 +7,11 @@ the Openshift HAProxy router, and the requests are routed to the appropriate bac
 
 import pytest
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.echoed_request import EchoedRequest
 
 pytestmark = [
     pytest.mark.nopersistence,
-    pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+    pytest.mark.require_version("2.11"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6849")
 ]
 

--- a/testsuite/tests/apicast/policy/url_rewriting/test_url_rewriting_http_method.py
+++ b/testsuite/tests/apicast/policy/url_rewriting/test_url_rewriting_http_method.py
@@ -2,14 +2,12 @@
 Tests that the rules in the url_rewriting_policy can match also against the
 http method of the request.
 """
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 import pytest
 from testsuite.echoed_request import EchoedRequest
 from testsuite import rawobj
-from testsuite import TESTED_VERSION # noqa # pylint: disable=unused-import
 
 
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.9')")]
+pytestmark = [pytest.mark.require_version("2.9")]
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/policy/url_rewriting/test_url_rewriting_policy_with_apiap.py
+++ b/testsuite/tests/apicast/policy/url_rewriting/test_url_rewriting_policy_with_apiap.py
@@ -2,12 +2,11 @@
 Test if url rewriting policy works with APIAP
 """
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.8')"),
+    pytest.mark.require_version("2.8"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-4301")]
 
 

--- a/testsuite/tests/apicast/policy/url_rewriting_captures/test_http_methods.py
+++ b/testsuite/tests/apicast/policy/url_rewriting_captures/test_http_methods.py
@@ -4,12 +4,11 @@ In 2.10 version the HTTP methods were added
 """
 import pytest
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import rawobj, TESTED_VERSION # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.echoed_request import EchoedRequest
 
 
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.10')"),
+pytestmark = [pytest.mark.require_version("2.10"),
               pytest.mark.issue("https://issues.jboss.org/browse/THREESCALE-6270")]
 
 

--- a/testsuite/tests/apicast/policy/websocket/test_websocket_policy_app_id.py
+++ b/testsuite/tests/apicast/policy/websocket/test_websocket_policy_app_id.py
@@ -1,16 +1,14 @@
 """Basic test for websocket policy with product secured with app id"""
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 import pytest
 from threescale_api.resources import Service
 
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.tests.apicast.policy.websocket.conftest import retry_sucessful, retry_failing
 
 # websockets may fail on some deployments probably because of TLS config mismatch
 pytestmark = [
         pytest.mark.sandbag,
-        pytest.mark.skipif("TESTED_VERSION < Version('2.8')")]
+        pytest.mark.require_version("2.8")]
 
 
 @pytest.fixture

--- a/testsuite/tests/apicast/policy/websocket/test_websocket_policy_user_key.py
+++ b/testsuite/tests/apicast/policy/websocket/test_websocket_policy_user_key.py
@@ -1,15 +1,13 @@
 """Basic test for websocket policy with product secured with user_key"""
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 import pytest
 
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.tests.apicast.policy.websocket.conftest import retry_sucessful, retry_failing
 
 # websockets may fail on some deployments probably because of TLS config mismatch
 pytestmark = [
         pytest.mark.sandbag,
-        pytest.mark.skipif("TESTED_VERSION < Version('2.8')")]
+        pytest.mark.require_version("2.8")]
 
 
 @pytest.fixture

--- a/testsuite/tests/apicast/policy/websocket/test_websocket_policy_wss_backend.py
+++ b/testsuite/tests/apicast/policy/websocket/test_websocket_policy_wss_backend.py
@@ -1,15 +1,14 @@
 """Basic test for websocket policy with wss backend_api"""
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 import pytest
 
-from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.tests.apicast.policy.websocket.conftest import retry_sucessful, retry_failing
 
 # websockets may fail on some deployments probably because of TLS config mismatch
 pytestmark = [
         pytest.mark.sandbag,
-        pytest.mark.skipif("TESTED_VERSION < Version('2.8')")]
+        pytest.mark.require_version("2.8")]
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/test_strip_standard_https_ports.py
+++ b/testsuite/tests/apicast/test_strip_standard_https_ports.py
@@ -3,14 +3,13 @@ When APIcast sends a request to a standard port, it should strip the port from t
 """
 import pytest
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.echoed_request import EchoedRequest
 from testsuite.utils import blame
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+    pytest.mark.require_version("2.11"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-2235")]
 
 

--- a/testsuite/tests/apicast/webhooks/test_webhook_user.py
+++ b/testsuite/tests/apicast/webhooks/test_webhook_user.py
@@ -4,16 +4,14 @@ Based on spec/ui_specs/webhooks/webhooks_users_spec.rb (ruby test is via UI)
 
 import xml.etree.ElementTree as Et
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 import pytest
 
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.utils import blame
 
 # webhook tests seem disruptive to requestbin as they reset it with no mercy
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.8.3')"),
+    pytest.mark.require_version("2.8.3"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-5207"),
     pytest.mark.disruptive]
 

--- a/testsuite/tests/apicast/webhooks/test_webhooks_account.py
+++ b/testsuite/tests/apicast/webhooks/test_webhooks_account.py
@@ -4,16 +4,14 @@ Based on spec/ui_specs/webhooks/webhooks_accounts_spec.rb (ruby test is via UI)
 
 import xml.etree.ElementTree as Et
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 import pytest
 
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.utils import blame
 
 # webhook tests seem disruptive to requestbin as they reset it with no mercy
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.8.3')"),
+    pytest.mark.require_version("2.8.3"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-5207"),
     pytest.mark.disruptive]
 

--- a/testsuite/tests/apicast/webhooks/test_webhooks_applications.py
+++ b/testsuite/tests/apicast/webhooks/test_webhooks_applications.py
@@ -4,17 +4,15 @@ Based on spec/ui_specs/webhooks/webhooks_applications_spec.rb (ruby test is via 
 
 import xml.etree.ElementTree as Et
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 import pytest
 
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite import rawobj
 from testsuite.utils import blame
 
 # webhook tests seem disruptive to requestbin as they reset it with no mercy
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.8.3')"),
+    pytest.mark.require_version("2.8.3"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-5207"),
     pytest.mark.disruptive]
 

--- a/testsuite/tests/apicast/webhooks/test_webhooks_keys.py
+++ b/testsuite/tests/apicast/webhooks/test_webhooks_keys.py
@@ -2,16 +2,14 @@
 Based on spec/ui_specs/webhooks/webhooks_keys_spec.rb (ruby test is via UI)
 """
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 import pytest
 
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.utils import blame
 
 # webhook tests seem disruptive to requestbin as they reset it with no mercy
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.8.3')"),
+    pytest.mark.require_version("2.8.3"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-5207"),
     pytest.mark.disruptive]
 

--- a/testsuite/tests/apicast_operator/test_annotations.py
+++ b/testsuite/tests/apicast_operator/test_annotations.py
@@ -4,9 +4,7 @@ Check if annotations of apicast-operator pod are present
 from typing import Tuple, List, Union
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import APICAST_OPERATOR_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.capabilities import Capability
 
 pytestmark = [
@@ -36,7 +34,7 @@ ANNOTATIONS_POST_2_12: List[Union[Tuple[str, str], Tuple[str, None]]] = [
 ]
 
 
-@pytest.mark.skipif("APICAST_OPERATOR_VERSION >  Version('0.6.0')")  # since threescale 2.12
+@pytest.mark.before_apicast_operator_version("0.7.0")  # since threescale 2.12
 @pytest.mark.parametrize("annotation,expected_value", ANNOTATIONS_PRE_2_12)
 def test_labels_operator_old(annotation, expected_value, operator):
     """ Test labels of operator pod. """
@@ -46,7 +44,7 @@ def test_labels_operator_old(annotation, expected_value, operator):
         assert value == expected_value
 
 
-@pytest.mark.skipif("APICAST_OPERATOR_VERSION <= Version('0.6.0')")
+@pytest.mark.require_apicast_operator_version("0.7.0")
 @pytest.mark.parametrize("annotation,expected_value", ANNOTATIONS_POST_2_12)
 def test_labels_operator_new(annotation, expected_value, operator):
     """ Test labels of operator pod. """

--- a/testsuite/tests/apicast_operator/test_labels.py
+++ b/testsuite/tests/apicast_operator/test_labels.py
@@ -4,9 +4,7 @@ Check if labels of apicast operator pod are present
 from typing import Tuple, List, Union
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import APICAST_OPERATOR_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.capabilities import Capability
 
 pytestmark = [
@@ -33,7 +31,7 @@ LABELS_POST_2_12: List[Union[Tuple[str, str], Tuple[str, None]]] = [
 ]
 
 
-@pytest.mark.skipif("APICAST_OPERATOR_VERSION >  Version('0.6.0')")  # since threescale 2.12
+@pytest.mark.before_apicast_operator_version("0.7.0")  # since threescale 2.12
 @pytest.mark.parametrize("label,expected_value", LABELS_PRE_2_12)
 def test_labels_operator_old(label, expected_value, operator):
     """ Test labels of apicast operator pod. """
@@ -43,7 +41,7 @@ def test_labels_operator_old(label, expected_value, operator):
         assert value == expected_value
 
 
-@pytest.mark.skipif("APICAST_OPERATOR_VERSION <= Version('0.6.0')")
+@pytest.mark.require_apicast_operator_version("0.7.0")
 @pytest.mark.parametrize("label,expected_value", LABELS_POST_2_12)
 def test_labels_operator_new(label, expected_value, operator, logger):
     """ Test labels of apicast operator pod. """

--- a/testsuite/tests/grafana/test_dashboards.py
+++ b/testsuite/tests/grafana/test_dashboards.py
@@ -1,12 +1,10 @@
 """Tests for Grafana Dashboards definitions"""
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.capabilities import Capability
 
 pytestmark = [
-        pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
+        pytest.mark.require_version("2.9"),
         pytest.mark.required_capabilities(Capability.OCP4),
     ]
 

--- a/testsuite/tests/operator/test_annotations.py
+++ b/testsuite/tests/operator/test_annotations.py
@@ -4,9 +4,7 @@ Check if annotations of operator pod are present
 from typing import Tuple, List, Union
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.capabilities import Capability
 
 pytestmark = [
@@ -36,7 +34,7 @@ ANNOTATIONS_POST_2_12: List[Union[Tuple[str, str], Tuple[str, None]]] = [
 ]
 
 
-@pytest.mark.skipif("TESTED_VERSION >= Version('2.12')")
+@pytest.mark.before_version("2.12")
 @pytest.mark.parametrize("annotation,expected_value", ANNOTATIONS_PRE_2_12)
 def test_labels_operator_old(annotation, expected_value, operator):
     """ Test labels of operator pod. """
@@ -46,7 +44,7 @@ def test_labels_operator_old(annotation, expected_value, operator):
         assert value == expected_value
 
 
-@pytest.mark.skipif("TESTED_VERSION < Version('2.12')")
+@pytest.mark.require_version("2.12")
 @pytest.mark.parametrize("annotation,expected_value", ANNOTATIONS_POST_2_12)
 def test_labels_operator_new(annotation, expected_value, operator):
     """ Test labels of operator pod. """

--- a/testsuite/tests/operator/test_labels.py
+++ b/testsuite/tests/operator/test_labels.py
@@ -4,9 +4,7 @@ Check if labels of operator pod are present
 from typing import Tuple, List, Union
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.capabilities import Capability
 
 pytestmark = [
@@ -36,7 +34,7 @@ LABELS_POST_2_12: List[Union[Tuple[str, str], Tuple[str, None]]] = [
 ]
 
 
-@pytest.mark.skipif("TESTED_VERSION >= Version('2.12')")
+@pytest.mark.before_version("2.12")
 @pytest.mark.parametrize("label,expected_value", LABELS_PRE_2_12)
 def test_labels_operator_old(label, expected_value, operator):
     """ Test labels of operator pod. """
@@ -46,7 +44,7 @@ def test_labels_operator_old(label, expected_value, operator):
         assert value == expected_value
 
 
-@pytest.mark.skipif("TESTED_VERSION < Version('2.12')")
+@pytest.mark.require_version("2.12")
 @pytest.mark.parametrize("label,expected_value", LABELS_POST_2_12)
 def test_labels_operator_new(label, expected_value, operator):
     """ Test labels of operator pod. """

--- a/testsuite/tests/operator/test_operator_resources.py
+++ b/testsuite/tests/operator/test_operator_resources.py
@@ -11,7 +11,7 @@ from testsuite.capabilities import Capability
 
 pytestmark = [
     pytest.mark.sandbag,  # requires operator in same namespace
-    pytest.mark.skipif("TESTED_VERSION < Version('2.10')"),
+    pytest.mark.require_version("2.10"),
     pytest.mark.required_capabilities(Capability.OCP4)
 ]
 

--- a/testsuite/tests/prometheus/apicast/selfmanaged/test_batching_caching_policy.py
+++ b/testsuite/tests/prometheus/apicast/selfmanaged/test_batching_caching_policy.py
@@ -4,13 +4,12 @@ Test Prometheus metric for content_caching.
 from datetime import datetime, timedelta
 import pytest
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import APICAST_OPERATOR_VERSION, rawobj  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 from testsuite.capabilities import Capability
 
 pytestmark = [
     pytest.mark.nopersistence,
-    pytest.mark.skipif("APICAST_OPERATOR_VERSION < Version('0.5.2')"),
+    pytest.mark.require_apicast_operator_version("0.5.2"),
     pytest.mark.required_capabilities(Capability.OCP4, Capability.APICAST),
     ]
 

--- a/testsuite/tests/prometheus/apicast/test_content_caching_policy.py
+++ b/testsuite/tests/prometheus/apicast/test_content_caching_policy.py
@@ -5,11 +5,10 @@ Test Prometheus metric for content_caching.
 import backoff
 import pytest
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
+    pytest.mark.require_version("2.9"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-5439"),
     ]
 

--- a/testsuite/tests/prometheus/apicast/test_metric_worker_starts.py
+++ b/testsuite/tests/prometheus/apicast/test_metric_worker_starts.py
@@ -5,10 +5,8 @@ https://issues.redhat.com/browse/THREESCALE-5965
 
 import pytest
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
 
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.9.1')"),
+pytestmark = [pytest.mark.require_version("2.9.1"),
               pytest.mark.disruptive,
               ]
 

--- a/testsuite/tests/prometheus/apicast/test_metrics.py
+++ b/testsuite/tests/prometheus/apicast/test_metrics.py
@@ -4,10 +4,8 @@ Test metrics provided by apicast to Prometheus.
 """
 import backoff
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 from testsuite.capabilities import Capability
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 
 pytestmark = [
     pytest.mark.required_capabilities(Capability.PRODUCTION_GATEWAY),

--- a/testsuite/tests/prometheus/backend_listener/test_backend_listener_api.py
+++ b/testsuite/tests/prometheus/backend_listener/test_backend_listener_api.py
@@ -7,11 +7,10 @@ status code, is expected in prometheus.
 
 import pytest
 import requests
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 from testsuite.rhsso.rhsso import OIDCClientAuthHook
 from testsuite.utils import blame, randomize
-from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 
 NUM_OF_REQUESTS = 10
 
@@ -19,7 +18,7 @@ pytestmark = [
     # can not be run in parallel
     pytest.mark.disruptive,
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-4641"),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.10')"),
+    pytest.mark.require_version("2.10"),
 ]
 
 

--- a/testsuite/tests/prometheus/backend_listener/test_backend_listener_internal_api.py
+++ b/testsuite/tests/prometheus/backend_listener/test_backend_listener_internal_api.py
@@ -7,10 +7,8 @@ import base64
 
 import pytest
 import requests
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 from threescale_api.resources import Service
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 
 
 NUM_OF_REQUESTS = 10
@@ -19,7 +17,7 @@ pytestmark = [
     # can not be run in parallel
     pytest.mark.disruptive,
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6453"),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.10')"),
+    pytest.mark.require_version("2.10"),
 ]
 
 

--- a/testsuite/tests/prometheus/backend_listener/test_backend_worker_report_jobs.py
+++ b/testsuite/tests/prometheus/backend_listener/test_backend_worker_report_jobs.py
@@ -5,9 +5,6 @@ the report jobs metric in prometheus is increased.
 
 import pytest
 import requests
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 
 
 NUM_OF_REQUESTS = 10
@@ -16,7 +13,7 @@ pytestmark = [
     # can not be run in parallel
     pytest.mark.disruptive,
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-3176"),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.10')"),
+    pytest.mark.require_version("2.10"),
 ]
 
 

--- a/testsuite/tests/prometheus/system/test_internal_calls.py
+++ b/testsuite/tests/prometheus/system/test_internal_calls.py
@@ -6,12 +6,9 @@ import base64
 import pytest
 import requests
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
-
 pytestmark = [
     pytest.mark.disruptive,
-    pytest.mark.skipif("TESTED_VERSION < Version('2.10')"),
+    pytest.mark.require_version("2.10"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6446"),
 ]
 

--- a/testsuite/tests/prometheus/system/test_metrics.py
+++ b/testsuite/tests/prometheus/system/test_metrics.py
@@ -3,9 +3,7 @@ When request is sent to system, requests metric in prometheus is increased.
 """
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 
 METRICS_MASTER = [
     # new metrics introduced in THREESCALE-4743
@@ -37,7 +35,7 @@ METRICS_SIDEKIQ = [
 pytestmark = [
     pytest.mark.sandbag,  # requires openshfit
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-4743"),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.10')"),
+    pytest.mark.require_version("2.10"),
 ]
 
 

--- a/testsuite/tests/prometheus/zync/test_annotations.py
+++ b/testsuite/tests/prometheus/zync/test_annotations.py
@@ -3,15 +3,13 @@ Check if annotations required by prometheus are set
 """
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.configuration import openshift
 
 pytestmark = [
     pytest.mark.sandbag,  # requires openshift
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6509"),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.10')"),
+    pytest.mark.require_version("2.10"),
 ]
 
 ANNOTATIONS = [

--- a/testsuite/tests/prometheus/zync/test_metrics.py
+++ b/testsuite/tests/prometheus/zync/test_metrics.py
@@ -3,14 +3,12 @@ Check if all keys  are avaiable in Prometheus
 """
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 
 pytestmark = [
     pytest.mark.sandbag,  # requires openshift
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-4642"),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.10')"),
+    pytest.mark.require_version("2.10"),
 ]
 
 METRICS_QUE = [

--- a/testsuite/tests/system/analytics/test_backend_analytics.py
+++ b/testsuite/tests/system/analytics/test_backend_analytics.py
@@ -3,11 +3,10 @@ Tests the analytics at the backend level
 """
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
+    pytest.mark.require_version("2.9"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-3159")]
 
 

--- a/testsuite/tests/system/analytics/test_infinite_time_range.py
+++ b/testsuite/tests/system/analytics/test_infinite_time_range.py
@@ -10,13 +10,10 @@ from datetime import datetime, timedelta
 
 import pytest
 from threescale_api.errors import ApiClientError
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-
-from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
 
 pytestmark = [
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6649"),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.11')")
+    pytest.mark.require_version("2.11")
 ]
 
 

--- a/testsuite/tests/system/test_http_routes.py
+++ b/testsuite/tests/system/test_http_routes.py
@@ -4,15 +4,13 @@ Test that http routes will be created and managed by zync
 
 from urllib.parse import urlparse
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 import pytest
 
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.capabilities import Capability
 
 # This test can be done only with system apicast
-pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
+pytestmark = [pytest.mark.require_version("2.9"),
               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-3545"),
               pytest.mark.required_capabilities(Capability.SAME_CLUSTER, Capability.PRODUCTION_GATEWAY),
               pytest.mark.disruptive]

--- a/testsuite/tests/system/test_system_redis_secret.py
+++ b/testsuite/tests/system/test_system_redis_secret.py
@@ -1,8 +1,6 @@
 """ Tests for MessageBus variables in system-redis secret """
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 
 pytestmark = [
     pytest.mark.sandbag,  # requires openshift
@@ -23,14 +21,14 @@ def system_redis_secret(openshift):
     return secret
 
 
-@pytest.mark.skipif("TESTED_VERSION >= Version('2.12')")
+@pytest.mark.before_version("2.12")
 @pytest.mark.parametrize("key", KEYS)
 def test_message_bus_secrets(system_redis_secret, key):
     """ test of env variable presence """
     assert key in system_redis_secret
 
 
-@pytest.mark.skipif("TESTED_VERSION < Version('2.12')")
+@pytest.mark.require_version("2.12")
 @pytest.mark.parametrize("key", KEYS)
 def test_message_bus_secrets_missing(system_redis_secret, key):
     """ test of env variable absence """

--- a/testsuite/tests/toolbox/test_backend.py
+++ b/testsuite/tests/toolbox/test_backend.py
@@ -5,14 +5,12 @@ import random
 import string
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 from testsuite.config import settings
 from testsuite.toolbox import toolbox
 import testsuite.utils
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 
-pytestmark = pytest.mark.skipif("TESTED_VERSION < Version('2.7')")
+pytestmark = pytest.mark.require_version("2.7")
 
 HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS', 'PATCH']
 # 'TRACE', 'CONNECT' are not supported by 3scale

--- a/testsuite/tests/toolbox/test_cli.py
+++ b/testsuite/tests/toolbox/test_cli.py
@@ -4,12 +4,10 @@ import re
 import os
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 from testsuite.toolbox import toolbox
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 
-pytestmark = pytest.mark.skipif("TESTED_VERSION < Version('2.7')")
+pytestmark = pytest.mark.require_version("2.7")
 
 # removed 'update' as unsupported command
 

--- a/testsuite/tests/toolbox/test_product_copy.py
+++ b/testsuite/tests/toolbox/test_product_copy.py
@@ -3,13 +3,12 @@
 import re
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 from testsuite.toolbox import toolbox
 from testsuite.utils import blame, blame_desc
-from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 
-pytestmark = pytest.mark.skipif("TESTED_VERSION < Version('2.7')")
+pytestmark = pytest.mark.require_version("2.7")
 
 
 @pytest.fixture(scope="module", params=['copy_service', 'product_copy', 'service_copy'])

--- a/testsuite/tests/toolbox/test_product_update.py
+++ b/testsuite/tests/toolbox/test_product_update.py
@@ -3,13 +3,12 @@
 import re
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 from testsuite.toolbox import toolbox
 from testsuite.utils import blame, blame_desc
-from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite import rawobj
 
-pytestmark = pytest.mark.skipif("TESTED_VERSION < Version('2.7')")
+pytestmark = pytest.mark.require_version("2.7")
 
 
 @pytest.fixture(scope="module", params=['product_copy', 'service_copy'])

--- a/testsuite/tests/ui/apiap/test_public_base_url.py
+++ b/testsuite/tests/ui/apiap/test_public_base_url.py
@@ -1,14 +1,12 @@
 """Test for Public Base URLs as localhost"""
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 from widgetastic.widget import Text
 
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.ui.views.admin.product.integration.settings import ProductSettingsView
 
 pytestmark = [
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-7149"),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.12')")
+    pytest.mark.require_version("2.12")
 ]
 
 

--- a/testsuite/tests/ui/policies/test_tls_termination_policy_in_ui.py
+++ b/testsuite/tests/ui/policies/test_tls_termination_policy_in_ui.py
@@ -5,9 +5,7 @@
 import pytest
 import requests
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 
 from testsuite import rawobj
 from testsuite.capabilities import Capability
@@ -22,7 +20,7 @@ from testsuite.tests.apicast.policy.tls.conftest import require_openshift, stagi
     gateway_options, gateway_environment
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+    pytest.mark.require_version("2.11"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6390")]
 
 

--- a/testsuite/tests/ui/security/test_xss_vulnerability.py
+++ b/testsuite/tests/ui/security/test_xss_vulnerability.py
@@ -1,8 +1,6 @@
 """Tests aimed to test XSS vulnerabilities"""
 import pytest
 
-from packaging.version import Version  # noqa # pylint: disable=unused-import
-from testsuite import TESTED_VERSION # noqa # pylint: disable=unused-import
 from testsuite.utils import blame
 
 from testsuite.ui.views.admin.backend.backend import BackendDetailView
@@ -10,7 +8,7 @@ from testsuite.ui.views.admin.audience.messages import SupportEmailsView
 
 pytestmark = [
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6785"),
-    pytest.mark.skipif("TESTED_VERSION < Version('2.11')")]
+    pytest.mark.require_version("2.11")]
 
 
 @pytest.fixture()

--- a/testsuite/tests/ui/users_and_roles/test_no_access_message.py
+++ b/testsuite/tests/ui/users_and_roles/test_no_access_message.py
@@ -1,15 +1,13 @@
 """Test for no access message in Dashboard"""
 
 import pytest
-from packaging.version import Version  # noqa # pylint: disable=unused-import
 from selenium.webdriver.common.by import By
 
-from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.ui.views.admin.audience.support_emails import SupportEmailsView
 from testsuite.ui.views.admin.foundation import DashboardView
 
 pytestmark = [
-    pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
+    pytest.mark.require_version("2.11"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6321")]
 
 


### PR DESCRIPTION
Try to use custom markers and special handling to skip tests that aren't
relevant to specific 3scale version.

Builtin skipif mark is better as there is no new code and no new
behavior, however... Having two imports (that must be ignored in checks)
and repeating still same conditions is pretty inconvenient. Furthermore
custom marks create standardized behavior that doesn't allow "creative"
conditions.
