### PR TITLE
Optimistic approving github action ;-)

### DIFF
--- a/.github/workflows/github_pr_approve.yaml
+++ b/.github/workflows/github_pr_approve.yaml
@@ -1,0 +1,17 @@
+name: github_pr_approve
+on:
+  schedule:
+    - cron: 0 0 * * *
+jobs:
+  github_pr_approve:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: support stale approve
+        # This provides extra approve for any PR that has:
+        #   at least 2 reviews requested,
+        #   at least one approve already provided,
+        #   the approve is at least 10 days old.
+        run: gh pr list --json number,reviewRequests,reviews --jq '.[]|select((.reviewRequests|length > 1) and (.reviews[]|select(.state == "APPROVED" and (.submittedAt|fromdateiso8601 < now - 10*24*60*60))|length > 1) and ([.reviews[].state]|contains(["CHANGES_REQUESTED", "COMMENTED"])|not)).number' | xargs -r -l gh pr review --approve
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOTBEZBOT_TOKEN }}


### PR DESCRIPTION
This si a regular action that tries move forward stale PRs. If there is
a PR with 1 approve already that is 10 days old, then bot adds another
approval. This happens only if at least two reviews are requested. So
author has to request two reviews, one approval has to be granted and
that has to be 10 days old.

This doesn't mean automatic merge, it "just" unblocks the merge. It is
still on the merger if it is merged or not.
