### PR TITLE
tr instead of xargs -d

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ else
 	docker build `$(RUNSCRIPT)semver-docker-tags "-t $(IMAGENAME)" $(_version) 4` .
 endif
 ifdef PUSHIMAGE
-	$(RUNSCRIPT)semver-docker-tags $(IMAGENAME) $(_version) 4|xargs -d' ' -l docker push
+	$(RUNSCRIPT)semver-docker-tags $(IMAGENAME) $(_version) 4|tr ' ' '\n'|xargs -l docker push
 endif
 	-[ -n "$$NOSWITCH" ] || git checkout -
 


### PR DESCRIPTION
xargs -d' ' didn't do the job as expected, replacement before xargs with
tr should be the way to go.
