### PR TITLE
Use pty in test-in-docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ test-in-docker:
 	docker network create $(network)
 	docker run -d --name $(selenium_name) --network $(network) --network-alias selenium -v /dev/shm:/dev/shm $(selenium_image)
 	-docker run \
+		-it \
 		--rm \
 		--network $(network) \
 		-v `readlink -f $(SECRETS_FOR_DYNACONF)`:/opt/secrets.yaml:z \


### PR DESCRIPTION
Allocated pty (and open STDIN) enables "usual" output from testsuite
(formatting, colors) and interactive use (debugging).
