### PR TITLE
Make umask setting for non-interactive shell right

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,9 @@ ENV SSL_CERT_FILE=/etc/pki/tls/certs/ca-bundle.crt
 ENV WORKON_HOME=/opt/workdir/virtualenvs
 ENV junit=yes
 ENV resultsdir=/test-run-results
+ENV BASH_ENV=~/.profile
 
-RUN echo umask 002 >>$HOME/.bashrc \
+RUN echo umask 002 | tee -a $HOME/.profile >>$HOME/.bashrc \
 	&& make mostlyclean pipenv \
 	&& rm -Rf $HOME/.cache/*
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@
 	container-image \
 	clean
 
+SHELL = /bin/bash
+
 TB ?= short
 LOGLEVEL ?= INFO
 


### PR DESCRIPTION
Non-interactive shell doesn't load usual files, furthermore /bin/sh
symlink behaves differently. Therefore:
 - Makefile uses bash explicitly (nobody with weird settings will
   "break" make anymore)
 - set BASH_ENV variable
 - Use separate file to minimize unexpected changes
