### PR TITLE
Rename manual github actions to give them clear order

### DIFF
--- a/.github/workflows/dispatch_1_rc_pullrequest.yaml
+++ b/.github/workflows/dispatch_1_rc_pullrequest.yaml
@@ -1,4 +1,4 @@
-name: dispatch_release_pullrequest
+name: dispatch_1_rc_pullrequest
 on:
   workflow_dispatch:
     inputs:
@@ -7,7 +7,7 @@ on:
         description: "Use x.y.z format e.g. 2.12.0 or KEEP EMPTY"
         type: string
 jobs:
-  dispatch_release_pullrequest:
+  dispatch_1_rc_pullrequest:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/dispatch_5_github_release.yaml
+++ b/.github/workflows/dispatch_5_github_release.yaml
@@ -1,9 +1,9 @@
-name: dispatch_github_release
+name: dispatch_5_github_release
 on:
   workflow_dispatch
 
 jobs:
-  dispatch_github_release:
+  dispatch_5_github_release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
First action includes 'rc' in name.
Actions are numbered in accordance to necessary manual steps:
 1. make a pull request
 2. review
 3. merge
 4. test
 5. create final release
