### PR TITLE
Set id for tools step in make_dist

### DIFF
--- a/.github/workflows/make_dist.yaml
+++ b/.github/workflows/make_dist.yaml
@@ -27,11 +27,12 @@ jobs:
       - name: cacert
         run: echo "$CACERT_CONTENT" > $CACERT
       - name: tools
+        id: tools
         run: echo "::set-output name=url::$(gh api /repos/3scale-qe/tools/releases/latest --jq .tarball_url)"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: make dist
         run: make dist IMAGENAME="quay.io/rh_integration/3scale-testsuite" PUSHIMAGE=y
         env:
-          fetch_tools: ${{steps.tools.outputs.url}}
+          fetch_tools: ${{ steps.tools.outputs.url }}
 


### PR DESCRIPTION
An id of a step is used to adress its outputs and should be explicitly
set to make the addressing easied.
