### PR TITLE
Fix RHSSO Performance tests

### DIFF
--- a/testsuite/tests/performance/smoke/test_smoke_oidc.py
+++ b/testsuite/tests/performance/smoke/test_smoke_oidc.py
@@ -64,8 +64,8 @@ def test_smoke_oidc(applications, setup_benchmark, prod_client):
     """
     for app in applications:
         client = prod_client(app)
-        assert client.get("/0/anything").status_code == 200
-        assert client.post("/0/anything").status_code == 200
+        assert client.get("/0/anything/").status_code == 200
+        assert client.post("/0/anything/").status_code == 200
 
     benchmark = setup_benchmark.create_benchmark()
     run = benchmark.start()

--- a/testsuite/tests/performance/smoke/test_smoke_rhsso_tokens.py
+++ b/testsuite/tests/performance/smoke/test_smoke_rhsso_tokens.py
@@ -67,8 +67,8 @@ def test_rhsso_tokens(applications, prod_client, setup_benchmark):
     """
     for app in applications:
         client = prod_client(app)
-        assert client.get("/0/anything").status_code == 200
-        assert client.post("/0/anything").status_code == 200
+        assert client.get("/0/anything/").status_code == 200
+        assert client.post("/0/anything/").status_code == 200
 
     benchmark = setup_benchmark.create_benchmark()
     run = benchmark.start()


### PR DESCRIPTION
To sum it up, Httpbin-go knows only `/anyhing/` path and not `/anything` (expects a trailing slash), but on `/anything` it returns 301 with relative redirect to `/anything/` -> which our client uses and asks APIcast again with the new path (`APICAST/anything`) -> this doesn't conform with any mapping rules and returns 404....