### PR TITLE
Revert token changes in keycloak_role_check

### DIFF
--- a/testsuite/tests/apicast/policy/keycloak_role_check/conftest.py
+++ b/testsuite/tests/apicast/policy/keycloak_role_check/conftest.py
@@ -120,4 +120,5 @@ def get_rhsso_client(application, rhsso_service_info):
 
 def token(application, rhsso_service_info, username):
     """Access token for 3scale application that is connected with RHSSO"""
-    return rhsso_service_info.access_token(application)
+    app_key = application.keys.list()["keys"][0]["key"]["value"]
+    return rhsso_service_info.password_authorize(application["client_id"], app_key, username)["access_token"]


### PR DESCRIPTION
Actually wrong change here as the code explicitly sets username what
`access_token` method can't do
