### PR TITLE
Handle empty params standard way

### DIFF
--- a/testsuite/echoed_request.py
+++ b/testsuite/echoed_request.py
@@ -62,6 +62,8 @@ class _EchoApiRequest(EchoedRequest):
     def __init__(self, response: requests.Response) -> None:
         super().__init__(response)
         self.headers = self.__process_headers()
+        if isinstance(self.params, str) and len(self.params) == 0:
+            self.params = {}
 
     def __process_headers(self) -> CaseInsensitiveDict:
         headers = self.headers

--- a/testsuite/tests/apicast/policy/test_upstream_policy_empty_params.py
+++ b/testsuite/tests/apicast/policy/test_upstream_policy_empty_params.py
@@ -36,4 +36,4 @@ def test_upstream_policy_empty_params(api_client):
     assert response.status_code == 200
     echoed_request = EchoedRequest.create(response)
     assert echoed_request.path == "/v1"
-    assert echoed_request.params == ""
+    assert echoed_request.params == {}


### PR DESCRIPTION
echo-api returns empty string in case of no params, other return empty
dict, so empty dict is returned also for echo-api.
