### PR TITLE
Use proper/universal call to get uuid

### DIFF
--- a/testsuite/tests/apicast/parameters/policies/test_content_caching_policy_parameters.py
+++ b/testsuite/tests/apicast/parameters/policies/test_content_caching_policy_parameters.py
@@ -110,7 +110,7 @@ def client2(application2, api_client):
 
 def test_wont_cache(client, private_base_url):
     """Test that redirected request (302 status code) will not be cached"""
-    payload = {'url': private_base_url("echo_api")}
+    payload = {'url': f'{private_base_url("echo_api")}/uuid'}
     response = client.get("/httpbin/redirect-to", params=payload, headers=dict(origin="localhost"))
     # First request was redirected
     assert response.history[0].status_code == 302
@@ -134,12 +134,12 @@ def test_will_cache(client, client2):
     """
     Test that requests will be cached with status code 200 and the cache will expire after 30 seconds
     """
-    response = client.get("/echo-api/testing", headers=dict(origin="localhost"))
+    response = client.get("/echo-api/uuid", headers=dict(origin="localhost"))
     assert response.status_code == 200
     assert response.headers.get("X-Cache-Status") != "HIT"
     echoed_request = EchoedRequest.create(response)
 
-    response = client.get("/echo-api/testing", headers=dict(origin="localhost"))
+    response = client.get("/echo-api/uuid", headers=dict(origin="localhost"))
     assert response.status_code == 200
     assert response.headers.get("X-Cache-Status") == "HIT"
     echoed_request_cached = EchoedRequest.create(response)
@@ -148,7 +148,7 @@ def test_will_cache(client, client2):
     assert echoed_request.json['uuid'] == echoed_request_cached.json['uuid']
 
     # another service wont hit the cache with the same request
-    response = client2.get("/echo-api/testing", headers=dict(origin="localhost"))
+    response = client2.get("/echo-api/uuid", headers=dict(origin="localhost"))
     assert response.status_code == 200
     assert response.headers.get("X-Cache-Status") != "HIT"
 
@@ -159,7 +159,7 @@ def test_will_cache(client, client2):
     time.sleep(40)
 
     # request expired
-    response = client.get("/echo-api/testing", headers=dict(origin="localhost"))
+    response = client.get("/echo-api/uuid", headers=dict(origin="localhost"))
     assert response.status_code == 200
     assert response.headers.get("X-Cache-Status") == "EXPIRED"
     echoed_request_new = EchoedRequest.create(response)

--- a/testsuite/tests/apicast/policy/content_caching/test_content_caching.py
+++ b/testsuite/tests/apicast/policy/content_caching/test_content_caching.py
@@ -93,12 +93,12 @@ def test_caching_timeouts(client):
 
 def test_caching_body_check(client):
     """Check same body response"""
-    response = client.get('/test/test', headers=dict(origin="localhost"))
+    response = client.get('/uuid', headers=dict(origin="localhost"))
     assert response.status_code == 200
     assert response.headers.get("X-Cache-Status") != "HIT"
     echoed_request = EchoedRequest.create(response)
 
-    response = client.get('/test/test', headers=dict(origin="localhost"))
+    response = client.get('/uuid', headers=dict(origin="localhost"))
     assert response.status_code == 200
     assert response.headers.get("X-Cache-Status") == "HIT"
 

--- a/testsuite/tests/apicast/policy/content_caching/test_content_caching_apiap.py
+++ b/testsuite/tests/apicast/policy/content_caching/test_content_caching_apiap.py
@@ -101,17 +101,17 @@ def test_other_service_cache(client, client2):
     """
     Test that cache of one product will not be used on the request of another product to the same backend
     """
-    response = client.get("/echo-api/test", headers=dict(origin="localhost"))
+    response = client.get("/echo-api/uuid", headers=dict(origin="localhost"))
     assert response.status_code == 200
     assert response.headers.get("X-Cache-Status") != "HIT"
     echoed_request = EchoedRequest.create(response)
 
-    response = client.get("/echo-api/test", headers=dict(origin="localhost"))
+    response = client.get("/echo-api/uuid", headers=dict(origin="localhost"))
     assert response.status_code == 200
     assert response.headers.get("X-Cache-Status") == "HIT"
 
     # another service should not hit the cache on same path and same backend
-    response = client2.get("/echo-api/test", headers=dict(origin="localhost"))
+    response = client2.get("/echo-api/uuid", headers=dict(origin="localhost"))
     assert response.status_code == 200
     assert response.headers.get("X-Cache-Status") != "HIT"
     echoed_request2 = EchoedRequest.create(response)
@@ -120,7 +120,7 @@ def test_other_service_cache(client, client2):
     assert echoed_request.json['uuid'] != echoed_request2.json['uuid']
 
     # Request to first service should be still cached
-    response = client.get("/echo-api/test", headers=dict(origin="localhost"))
+    response = client.get("/echo-api/uuid", headers=dict(origin="localhost"))
     assert response.status_code == 200
     assert response.headers.get("X-Cache-Status") == "HIT"
 


### PR DESCRIPTION
echo-api returns uuid in all calls, but others not. Therefore `/uuid`
path has to be used that provides uuid from all httpbin*
