### PR TITLE
Unify gathering of echo-api name in maintenance_mode test

### DIFF
--- a/testsuite/tests/apicast/policy/maintenance_mode/config_cases_host.py
+++ b/testsuite/tests/apicast/policy/maintenance_mode/config_cases_host.py
@@ -8,7 +8,7 @@ from typing import Tuple
 from urllib.parse import urlparse
 
 
-def case_eq_host(status_code, private_base_url) -> Tuple[int, str, dict]:
+def case_eq_host(status_code, echo_api_base_url) -> Tuple[int, str, dict]:
     """Case path on maintenance"""
     message = "Echo API /test is currently Unavailable"
     policy_config = {
@@ -16,7 +16,7 @@ def case_eq_host(status_code, private_base_url) -> Tuple[int, str, dict]:
             {"left_type": "liquid",
              "right_type": "plain",
              "left": "{{ upstream.host }}",
-             "right": urlparse(private_base_url("echo_api")).hostname,
+             "right": urlparse(echo_api_base_url).hostname,
              "op": "=="}], "combine_op": "or"},
         "status": status_code,
         "message": message
@@ -25,7 +25,7 @@ def case_eq_host(status_code, private_base_url) -> Tuple[int, str, dict]:
     return status_code, f"{message}\n", policy_config
 
 
-def case_matches_host(status_code) -> Tuple[int, str, dict]:
+def case_matches_host(status_code, echo_api_base_url) -> Tuple[int, str, dict]:
     """Case regex path on maintenance"""
     message = "Echo API /test is currently Unavailable"
     policy_config = {
@@ -33,7 +33,7 @@ def case_matches_host(status_code) -> Tuple[int, str, dict]:
             {"left_type": "liquid",
              "right_type": "plain",
              "left": "{{ upstream.host }}",
-             "right": "echo-api",
+             "right": urlparse(echo_api_base_url).hostname.split(".", 1)[0],
              "op": "matches"}], "combine_op": "or"},
         "status": status_code,
         "message": message


### PR DESCRIPTION
Don't hardcode any piece of hostname as the backend service can change
even is symbolic name is 'echo_api'
