### PR TITLE
Use explicit service accepting http

### DIFF
--- a/testsuite/tests/apicast/policy/proxy/test_fuse_proxy_policy.py
+++ b/testsuite/tests/apicast/policy/proxy/test_fuse_proxy_policy.py
@@ -23,13 +23,20 @@ def policy_settings(testconfig):
 
 
 @pytest.fixture(scope="module")
+def private_base_url(private_base_url):
+    """Use service URL as backend to avoid hostname conflicts with router.
+    Don't use https"""
+    return private_base_url("mockserver+svc:1080")
+
+
+@pytest.fixture(scope="module")
 def backends_mapping(private_base_url, custom_backend):
     """
     Creates httpbin backend: "/"
     Proxy service used in this test does not support HTTP over TLS (https) protocol,
     therefore http is preferred instead
     """
-    return {"/": custom_backend("netty-proxy", private_base_url("httpbin_service"))}
+    return {"/": custom_backend("netty-proxy", private_base_url)}
 
 
 def test_http_proxy_policy(api_client, private_base_url):
@@ -41,4 +48,4 @@ def test_http_proxy_policy(api_client, private_base_url):
     assert response.status_code == 200
     headers = EchoedRequest.create(response).headers
     assert "Fuse-Camel-Proxy" in headers
-    assert headers["Source-Header"] in private_base_url("httpbin_service")
+    assert headers["Source-Header"] in private_base_url

--- a/testsuite/tests/apicast/test_strip_standard_https_ports.py
+++ b/testsuite/tests/apicast/test_strip_standard_https_ports.py
@@ -14,7 +14,7 @@ pytestmark = [
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-2235")]
 
 
-@pytest.fixture(scope="module", params=["httpbin_service",
+@pytest.fixture(scope="module", params=["mockserver+svc:1080",
                                         "httpbin",
                                         "httpbin_nossl"])
 def private_base_url_and_expected_port(private_base_url, request):


### PR DESCRIPTION
At this moment mockserver is the only service that accept http trafic on
(openshift) service level. The other used httpbin* is go-httpbin which
is configured to accept https only.

Therefore mockserver is set explicitly where http .svc is needed.

Note: in future different httpbin* .svc with http might be needed (e.g.
for some proxy tests where mockserver will be prox). This should be
covered when such need will occur and likely it will be two go-httpbin
instances.
