### PR TITLE
test http proxy

### DIFF
--- a/testsuite/tests/apicast/parameters/http_proxy/test_http_proxy.py
+++ b/testsuite/tests/apicast/parameters/http_proxy/test_http_proxy.py
@@ -22,7 +22,7 @@ def gateway_kind():
 @pytest.fixture(scope="module")
 def service_proxy_settings(private_base_url):
     "Dict of proxy settings to be used when service created"
-    return rawobj.Proxy(private_base_url("httpbin_service"))
+    return rawobj.Proxy(private_base_url("go-httpbin"))
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
- Use explicit service accepting http
- Use router based URL instead of .svc
