### PR TITLE
Use unique name for a fixture

### DIFF
--- a/testsuite/tests/apicast/policy/proxy/test_fuse_proxy_policy.py
+++ b/testsuite/tests/apicast/policy/proxy/test_fuse_proxy_policy.py
@@ -23,23 +23,23 @@ def policy_settings(testconfig):
 
 
 @pytest.fixture(scope="module")
-def private_base_url(private_base_url):
+def backend_url(private_base_url):
     """Use service URL as backend to avoid hostname conflicts with router.
     Don't use https"""
     return private_base_url("mockserver+svc:1080")
 
 
 @pytest.fixture(scope="module")
-def backends_mapping(private_base_url, custom_backend):
+def backends_mapping(backend_url, custom_backend):
     """
     Creates httpbin backend: "/"
     Proxy service used in this test does not support HTTP over TLS (https) protocol,
     therefore http is preferred instead
     """
-    return {"/": custom_backend("netty-proxy", private_base_url)}
+    return {"/": custom_backend("netty-proxy", backend_url)}
 
 
-def test_http_proxy_policy(api_client, private_base_url):
+def test_http_proxy_policy(api_client, backend_url):
     """
     Fuse proxy service should add extra Header: "Fuse-Camel-Proxy", when handling communication
     between Apicast and backend API
@@ -48,4 +48,4 @@ def test_http_proxy_policy(api_client, private_base_url):
     assert response.status_code == 200
     headers = EchoedRequest.create(response).headers
     assert "Fuse-Camel-Proxy" in headers
-    assert headers["Source-Header"] in private_base_url
+    assert headers["Source-Header"] in backend_url


### PR DESCRIPTION
private_base-url is a fixture used in global conftest as well, it's
behavior can't change. Unique name (different fixture) must be used for
local modification
