### PR TITLE
Revert "self-contained html report"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ PYTEST += --junitxml=$(resultsdir)/junit-$(@F).xml -o junit_suite_name=$(@F)
 endif
 
 ifdef html
-PYTEST += --html=$(resultsdir)/report-$(@F).html --self-contained-html
+PYTEST += --html=$(resultsdir)/report-$(@F).html
 endif
 
 ifeq ($(filter-out --store --load,$(flags)),$(flags))


### PR DESCRIPTION
This reverts commit a2d900ad9bf7cf13b0f3458480cd3c0eefe85b70.

It didn't do expected job, report is not properly displayed in jenkins.
Yet it broke jenkins jobs because of missing assets/ dir.
