### PR TITLE
Deploy all tools to same namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,8 +227,12 @@ fetch-tools:
 	-mkdir -p $(_targetdir)
 	-curl -L $(fetch_tools) | tar --strip-components=1 -C $(_targetdir) -xz
 
+# For now deploy all tools to same namespace, it is safe unless more deployment
+# methods are used. Different deployment method of tools should be used for such cases.
+tools: export THREESCALE_NAMESPACE ?= tools
+tools: export SHARED_NAMESPACE ?= tools
 tools:
-	SHARED_NAMESPACE=tools ./ext/testsuite-tools/run.sh
+	./ext/testsuite-tools/run.sh
 
 VERSION-required:
 ifndef VERSION


### PR DESCRIPTION
tools target allows instalation of tools services in the openshift. This
change install all the tools to same shared namespaces. Some tools are
installed to 3scale specific namespace because they can't be easily
shared between 3scale instances. tools target is supposed to cover
deployments where just one 3scale is installed therefore it is not a
problem.
