### PR TITLE
New wasm image and WasmPlugin custom resource support

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -13,6 +13,7 @@ default:
         template: apicast.yml
       WASMGateway:
         image: "registry.redhat.io/openshift-service-mesh/3scale-auth-wasm-rhel8:0.0.1"
+        pull_secret: "pull-secret"  # name of pull secret resource in same namespace as httpbin
       default:
         kind: "SystemApicast"
   rhsso:

--- a/testsuite/gateways/wasm/__init__.py
+++ b/testsuite/gateways/wasm/__init__.py
@@ -96,11 +96,10 @@ class WASMGateway(AbstractGateway):
     # pylint: disable=unused-argument, too-many-arguments
     def _create_api_client(self, application, endpoint, verify, cert=None, disable_retry_status_list=None):
         ext = self.extensions[application.service["id"]]
-        ext.synchronise_mapping_rules()
         ext.synchronise_credentials()
 
         # wait needed for WASM to load new configuration, fixme: should be replaced with wait for wasm sync
-        ext.httpbin.deployment(f"dc/{ext.httpbin_name}").rollout()
+        ext.httpbin.deployment(f"dc/{ext.httpbin_name}").wait_for()
         return ServiceMeshHttpClient(app=application,
                                      cert=cert,
                                      disable_retry_status_list=disable_retry_status_list,

--- a/testsuite/gateways/wasm/__init__.py
+++ b/testsuite/gateways/wasm/__init__.py
@@ -96,10 +96,9 @@ class WASMGateway(AbstractGateway):
     # pylint: disable=unused-argument, too-many-arguments
     def _create_api_client(self, application, endpoint, verify, cert=None, disable_retry_status_list=None):
         ext = self.extensions[application.service["id"]]
-        ext.synchronise_credentials()
+        if ext.synchronise_credentials():
+            ext.httpbin.deployment(f"dc/{ext.httpbin_name}").rollout()
 
-        # wait needed for WASM to load new configuration, fixme: should be replaced with wait for wasm sync
-        ext.httpbin.deployment(f"dc/{ext.httpbin_name}").wait_for()
         return ServiceMeshHttpClient(app=application,
                                      cert=cert,
                                      disable_retry_status_list=disable_retry_status_list,

--- a/testsuite/gateways/wasm/__init__.py
+++ b/testsuite/gateways/wasm/__init__.py
@@ -22,10 +22,12 @@ class WASMGateway(AbstractGateway):
     CAPABILITIES = {Capability.SERVICE_MESH, Capability.SERVICE_MESH_WASM}
 
     # pylint: disable=too-many-arguments
-    def __init__(self, httpbin: OpenShiftClient, mesh: OpenShiftClient, portal_endpoint, backend_host, image):
+    def __init__(self, httpbin: OpenShiftClient, mesh: OpenShiftClient,
+                 portal_endpoint, backend_host, image, pull_secret):
         self.label = generate_tail()
         self.httpbin = httpbin
         self.image = image
+        self.pull_secret = pull_secret
         self.mesh = mesh
 
         res = urlparse(portal_endpoint).netloc.split("@")
@@ -42,7 +44,8 @@ class WASMGateway(AbstractGateway):
 
     def on_service_create(self, service: Service):
         self.extensions[service["id"]] = WASMExtension(self.httpbin, self.mesh, self.portal_host, self.portal_token,
-                                                       self.backend_host, self.image, self.label, service)
+                                                       self.backend_host, self.image, self.label, service,
+                                                       self.pull_secret)
 
     def on_service_delete(self, service: Service):
         self.extensions[service["id"]].delete()

--- a/testsuite/gateways/wasm/extension.py
+++ b/testsuite/gateways/wasm/extension.py
@@ -195,4 +195,4 @@ class WASMExtension:
 
     def delete(self):
         """Deletes extension and all that it created from openshift"""
-        self.httpbin.delete_app(self.label, resources="all,wasmplugin,sme,gateway,virtualservice")
+        self.httpbin.delete_app(self.label, resources="all,wasmplugin,sme,gateways.networking.istio.io,virtualservice")

--- a/testsuite/gateways/wasm/extension.py
+++ b/testsuite/gateways/wasm/extension.py
@@ -29,8 +29,6 @@ class WASMExtension:
         })
 
         self.extension_name = f"threescale-extension-{self.service['id']}"
-        configuration = service.proxy.list().configs.list(env="production")[0]
-        token = configuration["proxy_config"]["content"]["backend_authentication_value"]
         self.httpbin.new_app(self.base_path.joinpath('plugin.yaml'), {
             "NAME": self.extension_name,
             "LABEL": self.label,
@@ -38,7 +36,6 @@ class WASMExtension:
             "SYSTEM_HOST": self.portal_endpoint,
             "SYSTEM_TOKEN": self.portal_token,
             "SERVICE_ID": service["id"],
-            "SERVICE_TOKEN": token,
             "IMAGE": image,
             "SELECTOR": self.label
         })
@@ -195,4 +192,4 @@ class WASMExtension:
 
     def delete(self):
         """Deletes extension and all that it created from openshift"""
-        self.httpbin.delete_app(self.label, resources="all,wasmplugin,sme,gateways.networking.istio.io,virtualservice")
+        self.httpbin.delete_app(self.label, resources="all,wasmplugin,gateways.networking.istio.io,virtualservice")

--- a/testsuite/gateways/wasm/extension.py
+++ b/testsuite/gateways/wasm/extension.py
@@ -11,7 +11,7 @@ class WASMExtension:
     """Class representing once instance of WASMExtension, including deployed Httpbin as there is 1:1 mapping"""
     # pylint: disable=too-many-arguments
     def __init__(self, httpbin: OpenShiftClient, mesh: OpenShiftClient, portal_endpoint,
-                 portal_token, backend_endpoint, image, parent_label, service: Service) -> None:
+                 portal_token, backend_endpoint, image, parent_label, service: Service, pull_secret) -> None:
         self.httpbin = httpbin
         self.mesh = mesh
         self.portal_endpoint = portal_endpoint
@@ -37,7 +37,8 @@ class WASMExtension:
             "SYSTEM_TOKEN": self.portal_token,
             "SERVICE_ID": service["id"],
             "IMAGE": image,
-            "SELECTOR": self.label
+            "SELECTOR": self.label,
+            "PULL_SECRET": pull_secret
         })
         self.credentials = None
 

--- a/testsuite/gateways/wasm/extension.py
+++ b/testsuite/gateways/wasm/extension.py
@@ -31,7 +31,7 @@ class WASMExtension:
         self.extension_name = f"threescale-extension-{self.service['id']}"
         configuration = service.proxy.list().configs.list(env="production")[0]
         token = configuration["proxy_config"]["content"]["backend_authentication_value"]
-        self.httpbin.new_app(self.base_path.joinpath('extension.yaml'), {
+        self.httpbin.new_app(self.base_path.joinpath('plugin.yaml'), {
             "NAME": self.extension_name,
             "LABEL": self.label,
             "BACKEND_HOST": self.backend_endpoint,
@@ -66,7 +66,7 @@ class WASMExtension:
             ops.append(
                 {
                     "op": "add",
-                    "path": "/spec/config/services/0/mapping_rules/-",
+                    "path": "/spec/pluginConfig/services/0/mapping_rules/-",
                     "value": {
                         "method": rule["http_method"],
                         "pattern": rule["pattern"],
@@ -80,23 +80,23 @@ class WASMExtension:
                     }
                 }
             )
-        self.httpbin.patch("sme", self.extension_name, ops, patch_type="json")
+        self.httpbin.patch("wasmplugin", self.extension_name, ops, patch_type="json")
 
     def remove_all_mapping_rules(self):
         """Remove all mapping rules in extension"""
         ops = [
             {
                 "op": "remove",
-                "path": "/spec/config/services/0/mapping_rules"
+                "path": "/spec/pluginConfig/services/0/mapping_rules"
             },
             {
                 "op": "add",
-                "path": "/spec/config/services/0/mapping_rules",
+                "path": "/spec/pluginConfig/services/0/mapping_rules",
                 "value": []
             }
         ]
 
-        self.httpbin.patch("sme", self.extension_name, ops, patch_type="json")
+        self.httpbin.patch("wasmplugin", self.extension_name, ops, patch_type="json")
 
     def synchronise_mapping_rules(self):
         """Take all mapping rules from current production config and deploy in extension"""
@@ -130,11 +130,11 @@ class WASMExtension:
 
             ops.append({
                 "op": "add",
-                "path": f"/spec/config/services/0/credentials/{cred['label']}/-",
+                "path": f"/spec/pluginConfig/services/0/credentials/{cred['label']}/-",
                 "value": obj
             })
 
-        self.httpbin.patch("sme", self.extension_name, ops, patch_type="json")
+        self.httpbin.patch("wasmplugin", self.extension_name, ops, patch_type="json")
 
     def remove_credentials(self, labels):
         """Remove credential with 'label' from extension"""
@@ -143,16 +143,16 @@ class WASMExtension:
             ops.extend([
                 {
                     "op": "remove",
-                    "path": f"/spec/config/services/0/credentials/{label}"
+                    "path": f"/spec/pluginConfig/services/0/credentials/{label}"
                 },
                 {
                     "op": "add",
-                    "path": f"/spec/config/services/0/credentials/{label}",
+                    "path": f"/spec/pluginConfig/services/0/credentials/{label}",
                     "value": []
                 }
             ])
 
-        self.httpbin.patch("sme", self.extension_name, ops, patch_type="json")
+        self.httpbin.patch("wasmplugin", self.extension_name, ops, patch_type="json")
 
     def remove_all_credentials(self):
         """Remove all credentials in extension"""
@@ -195,4 +195,4 @@ class WASMExtension:
 
     def delete(self):
         """Deletes extension and all that it created from openshift"""
-        self.httpbin.delete_app(self.label, resources="all,sme,gateway,virtualservice")
+        self.httpbin.delete_app(self.label, resources="all,wasmplugin,sme,gateway,virtualservice")

--- a/testsuite/resources/service_mesh/plugin.yaml
+++ b/testsuite/resources/service_mesh/plugin.yaml
@@ -1,0 +1,96 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: threescale-extension
+objects:
+- apiVersion: extensions.istio.io/v1alpha1
+  kind: WasmPlugin
+  metadata:
+    name: ${NAME}
+    labels:
+      app: ${LABEL}
+  spec:
+    url: oci://${IMAGE}
+    phase: AUTHZ
+    priority: 100
+    selector:
+      matchLabels:
+        app: ${SELECTOR}
+    pluginConfig:
+      api: v1
+      system:
+        name: system
+        upstream:
+          name: outbound|443||${SYSTEM_HOST}
+          url: "https://${SYSTEM_HOST}"
+          timeout: 5000
+        token: ${SYSTEM_TOKEN}
+      backend:
+        name: backend
+        upstream:
+          name: outbound|443||${BACKEND_HOST}
+          url: "https://${BACKEND_HOST}"
+          timeout: 5000
+        extensions:
+        - no_body
+      services:
+      - id: ${SERVICE_ID}
+        token: ${SERVICE_TOKEN}
+        authorities:
+        - "*"
+        credentials:
+          user_key:
+            - query_string:
+                keys:
+                  - user_key
+            - header:
+                keys:
+                  - user_key
+          app_id:
+            - header:
+                keys:
+                  - app_id
+            - query_string:
+                keys:
+                  - app_id
+          app_key:
+            - header:
+                keys:
+                  - app_key
+            - query_string:
+                keys:
+                  - app_key
+        mapping_rules:
+        - method: GET
+          pattern: "/"
+          usages:
+          - name: hits
+            delta: 1
+parameters:
+- name: NAME
+  description: "Name of the WASM extension"
+  required: true
+- name: SELECTOR
+  description: "Workload selector label"
+  required: true
+- name: SYSTEM_HOST
+  description: "Hostname (without protocol, port and path) of the system"
+  required: true
+- name: BACKEND_HOST
+  description: "Hostname (without protocol, port and path) of the backend"
+  required: true
+- name: SYSTEM_TOKEN
+  description: "System token"
+  required: true
+- name: SERVICE_ID
+  description: "Service ID"
+  required: true
+- name: SERVICE_TOKEN
+  description: "Service Token for backend authorization"
+  required: true
+- name: LABEL
+  description: "App label for all resources"
+  required: true
+- name: IMAGE
+  description: "3scale WASM extension image"
+  required: true

--- a/testsuite/resources/service_mesh/plugin.yaml
+++ b/testsuite/resources/service_mesh/plugin.yaml
@@ -35,7 +35,6 @@ objects:
         - no_body
       services:
       - id: ${SERVICE_ID}
-        token: ${SERVICE_TOKEN}
         authorities:
         - "*"
         credentials:
@@ -60,12 +59,6 @@ objects:
             - query_string:
                 keys:
                   - app_key
-        mapping_rules:
-        - method: GET
-          pattern: "/"
-          usages:
-          - name: hits
-            delta: 1
 parameters:
 - name: NAME
   description: "Name of the WASM extension"
@@ -87,7 +80,7 @@ parameters:
   required: true
 - name: SERVICE_TOKEN
   description: "Service Token for backend authorization"
-  required: true
+  required: false
 - name: LABEL
   description: "App label for all resources"
   required: true

--- a/testsuite/resources/service_mesh/plugin.yaml
+++ b/testsuite/resources/service_mesh/plugin.yaml
@@ -11,6 +11,7 @@ objects:
       app: ${LABEL}
   spec:
     url: oci://${IMAGE}
+    imagePullSecret: ${PULL_SECRET}
     phase: AUTHZ
     priority: 100
     selector:
@@ -86,4 +87,7 @@ parameters:
   required: true
 - name: IMAGE
   description: "3scale WASM extension image"
+  required: true
+- name: PULL_SECRET
+  description: "Name of registry secret for image pulling"
   required: true

--- a/testsuite/tests/apicast/test_limit_exceeded_metric.py
+++ b/testsuite/tests/apicast/test_limit_exceeded_metric.py
@@ -5,7 +5,6 @@ Test that limit exceeded metric returns status 429 or 403 if using WASMGateway
 
 import pytest
 from testsuite import rawobj
-from testsuite.gateways.wasm import WASMGateway
 
 pytestmark = [
     pytest.mark.nopersistence,
@@ -31,23 +30,14 @@ def application(application):
     return application
 
 
-@pytest.fixture(scope="session")
-def error_status_code_too_many(staging_gateway):
-    """'Too many requests' status codes
-        are different when using WASMGateway"""
-    if isinstance(staging_gateway, WASMGateway):
-        return 403
-    return 429
-
-
-def test_limit_exceeded(api_client, error_status_code_too_many):
-    """Call to /anything/exceeded should returns 429 Too Many Requests."""
+def test_limit_exceeded(api_client):
+    """Call to /anything/exceeded should return 429 Too Many Requests."""
     client = api_client()
 
     assert client.get("/anything/exceeded").status_code == 200
     # Apicast allows more request to pass than is the actual limit, other gateway do not
     client.get("/anything/exceeded")
-    assert client.get("/anything/exceeded").status_code == error_status_code_too_many
+    assert client.get("/anything/exceeded").status_code == 429
 
 
 def test_anything_else_is_ok(api_client):

--- a/testsuite/tests/system/mapping/test_mapping_rules.py
+++ b/testsuite/tests/system/mapping/test_mapping_rules.py
@@ -10,7 +10,6 @@ and return 404 response code or 403 if using WASMGateway
 
 import pytest
 from testsuite import rawobj
-from testsuite.gateways.wasm import WASMGateway
 
 pytestmark = pytest.mark.required_capabilities()
 
@@ -64,16 +63,7 @@ def client(application, api_client):
     return api_client(disable_retry_status_list={404})
 
 
-@pytest.fixture(scope="session")
-def error_status_code(staging_gateway):
-    """'Not found' / 'Method not allowed' status codes
-        are different when using WASMGateway"""
-    if isinstance(staging_gateway, WASMGateway):
-        return 403
-    return 404
-
-
-def test_mapping(client, endpoints_and_methods, error_status_code):
+def test_mapping(client, endpoints_and_methods):
     """
     Make following request calls and assert they succeed:
         - GET request call to '/ip'
@@ -100,7 +90,7 @@ def test_mapping(client, endpoints_and_methods, error_status_code):
     assert response.status_code == 200
 
     response = client.post("/ip")
-    assert response.status_code == error_status_code
+    assert response.status_code == 404
 
     response = client.get("/imaginary")
-    assert response.status_code == error_status_code
+    assert response.status_code == 404


### PR DESCRIPTION
This PR is dependent on yet unreleased wasm image. 
(for testing purposes, @pehala 's image can be used `quay.io/phala/threescale-wasm-auth:v16`)

- Adds support for new WasmPlugin
- Fixes gateways resource not deleting
- Removes mapping rules synchronization, as its not needed in new wasm image 
- Removes backend token synchronization, as its also not needed
- Remove special status code handling in tests as now correct status codes are returned
- Reduce openshift calls in credentials synchronization and rollout only if they were changed
- Add image pull secret support for wasm (_currently untested_)