### PR TITLE
Self-contained html report (again)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ PYTEST += --junitxml=$(resultsdir)/junit-$(@F).xml -o junit_suite_name=$(@F)
 endif
 
 ifdef html
-PYTEST += --html=$(resultsdir)/report-$(@F).html
+PYTEST += --html=$(resultsdir)/report-$(@F).html --self-contained-html
 endif
 
 ifeq ($(filter-out --store --load,$(flags)),$(flags))
@@ -135,7 +135,16 @@ Pipfile.lock: Pipfile
 	pipenv sync --dev
 	touch .make-pipenv-sync-dev .make-pipenv-sync
 
-pipenv: .make-pipenv-sync
+# this dir is created for compatibility with pipelines that try to collect
+# artifacts and expect this dir in case of html report
+$(resultsdir)/assets:
+	mkdir $@
+
+# a hack to ensure assets/ exists (explained few lines above) all targets that
+# should handle compatibility require pipenv (unfortunately few other targets
+# require pipenv but not assets/ so in rare cases assets/ is created without
+# purpose)
+pipenv: .make-pipenv-sync $(if $(and $(html), $(WORKSPACE)), $(resultsdir)/assets,)
 
 pipenv-dev: .make-pipenv-sync-dev
 


### PR DESCRIPTION
Due to default jenkins behavior neither self-contained nor standard html
report is optimal. self-contained requires modification of jenkins
settings (actually both require it, this one just need different value
for specific setting) on the other hand results in bit better behavior
at the end.

Both require change of content-security-policy header to enable
javascript. self-contained requires also inline css enabled.

On the other hand standard report has troubles with GSSAPI/Negotiate
auth when other files are denied with 403 (including images and applying
also on self-contained in this case).
