### PR TITLE
Ability to push the container also elsewhere

### DIFF
--- a/.github/workflows/make_dist.yaml
+++ b/.github/workflows/make_dist.yaml
@@ -24,6 +24,11 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: cacert
         run: echo "$CACERT_CONTENT" > $CACERT
       - name: tools
@@ -35,4 +40,5 @@ jobs:
         run: make dist IMAGENAME="quay.io/rh_integration/3scale-testsuite" PUSHIMAGE=y
         env:
           fetch_tools: ${{ steps.tools.outputs.url }}
+          PUSH_EXTRA: ghcr.io/${{ github.repository }}
 

--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,10 @@ else
 endif
 ifdef PUSHIMAGE
 	$(RUNSCRIPT)semver-docker-tags $(IMAGENAME) $(_version) 4|tr ' ' '\n'|xargs -l docker push
+ifdef PUSH_EXTRA
+	docker tag $(IMAGENAME) $(PUSH_EXTRA)
+	docker push $(PUSH_EXTRA)
+endif
 endif
 	-[ -n "$$NOSWITCH" ] || git checkout -
 


### PR DESCRIPTION
Besides the oficial container registry add ability to push the image
also to other place. This is not supposed to replace oficial record and
there aren't pushed any additional tags.

Use this feature and push to ghcr.io as well.
