### PR TITLE
Add web browser version to metadata

### DIFF
--- a/testsuite/tests/ui/conftest.py
+++ b/testsuite/tests/ui/conftest.py
@@ -45,7 +45,7 @@ def webdriver():
 
 
 @pytest.fixture(scope="module")
-def browser(webdriver, request):
+def browser(webdriver, request, metadata):
     """
     Browser representation based on UI settings
     Args:
@@ -55,6 +55,8 @@ def browser(webdriver, request):
     """
     browser = ThreeScaleBrowser(selenium=webdriver.start_session())
     request.addfinalizer(webdriver.finalize)
+    caps = webdriver.webdriver.webdriver.caps
+    metadata["Browser"] = f"{caps['browserName']} {caps['browserVersion']}"
     return browser
 
 


### PR DESCRIPTION
Adding information to metadata in ui conftest won't print this info in
the header on the console output, but it will be included in html report
(if generated) as well as in xml (if generated), so the information will
be retained and available.
