### PR TITLE
Remove xfail and replace it with skipif in APICAST_LOAD_SERVICES test

### DIFF
--- a/testsuite/tests/apicast/parameters/test_apicast_load_services.py
+++ b/testsuite/tests/apicast/parameters/test_apicast_load_services.py
@@ -1,7 +1,8 @@
 """Tests that APICAST_LOAD_SERVICES_WHEN_NEEDED loads all mapping rules"""
 import pytest
 
-from testsuite import rawobj
+from packaging.version import Version  # noqa # pylint: disable=unused-import
+from testsuite import rawobj, TESTED_VERSION # noqa # pylint: disable=unused-import
 from testsuite.capabilities import Capability
 
 from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
@@ -34,7 +35,7 @@ def service(backends_mapping, custom_service, service_proxy_settings, lifecycle_
 
 
 @pytest.mark.parametrize("load_service", [
-    pytest.param(True, marks=pytest.mark.xfail),
+    pytest.param(True, marks=pytest.mark.skipif("TESTED_VERSION < Version('2.13')")),
     False
 ])
 def test_mapping_rule_hit(api_client, staging_gateway, load_service):


### PR DESCRIPTION
The issue was fixed in 2.13.