### PR TITLE
Prometheus metrics can be in openshift user workload monitoring

### DIFF
--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -36,6 +36,9 @@ development:  # default dynaconf env
   integration:
     service:
       proxy_service: ${FUSE_CAMEL_URL}
+  prometheus:
+    url: "{PROMETHEUS_URL}"
+    token: "{PROMETHEUS_TOKEN}"
   fixtures:
     jaeger:
       config:

--- a/testsuite/prometheus.py
+++ b/testsuite/prometheus.py
@@ -3,10 +3,13 @@ import logging
 import time
 from datetime import datetime, timedelta
 from math import ceil
-from typing import Optional, Callable
+from typing import Optional, Callable, Dict
+from urllib.parse import urljoin
 
 import backoff
 import requests
+
+from testsuite import settings
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -17,107 +20,104 @@ PROMETHEUS_REFRESH = 30
 
 
 # pylint: disable=too-few-public-methods
+def _params(key: str = "", labels: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    """Generate prometheus query parameter from key and labels.
+
+    returns: Formatted query string for Prometheus.
+    Args:
+      :param key: Key name to be queried in prometheus
+      :param labels: Labels to be put inside {} of prometheus query
+    """
+
+    if not labels:
+        return {"query": key}
+    return {"query": "%s{%s}" % (key, ",".join(f"{k}='{v}'" for k, v in labels.items()))}
+
+
+def get_metrics_keys(metrics: list):
+    """get list of names from list returned by get_metrics"""
+    return {m["metric"]["__name__"] for m in metrics}
+
+
 class PrometheusClient:
     """Prometheus REST API Client.
 
     Note: Contains only methods being used by actual tests.
     """
 
-    def __init__(self, endpoint: str):
+    def __init__(self, endpoint: str, operator_based: bool = None):
+        """
+        Args:
+            :param endpoint: url where prometheus is deployed
+            :param operator_based: if prometheus is expected to gather new info based on PodMonitor or other CRD
+        """
         self.endpoint = endpoint
+        self.operator_based = operator_based
 
-    def get_metrics(self, target: str) -> set:
-        """Get metrics for a specific target.
-
-        Args:
-            :param target: target.
-        """
-        params = {
-            "match_target": "{container='%s'}" % target,
-        }
-        response = requests.get(f"{self.endpoint}/api/v1/targets/metadata", params=params)
-        response.raise_for_status()
-        metrics = response.json()
-        return {m["metric"] for m in metrics["data"]}
-
-    def get_metric(self, metric: str, timestamp: Optional[str] = None) -> dict:
-        """Get a metric byt metric name.
+    def _do_request(self, path: str, **kwargs):
+        """Make a request to prometheus api.
 
         Args:
-          :param metric: Metric name.
-          :param timestamp: Evaluation timestamp in rfc3339 or unix_timestamp
+            :param path: api endpoint to send request
+            :param **kwargs: arguments passed to be passed to requests (e.g. params)
         """
-        params = {
-            "query": metric,
-        }
-        if timestamp:
-            params["time"] = timestamp
+        url = urljoin(self.endpoint, path)
+        ssl_verify = settings["ssl_verify"]
 
-        response = requests.get(f"{self.endpoint}/api/v1/query", params=params)
+        return requests.get(url, verify=ssl_verify, **kwargs)
+
+    def get_metrics(self, key: str = "", labels: Optional[Dict[str, str]] = None) -> list:
+        """Get a metric by metric key or labels.
+
+        Args:
+          :param key: Key name to be queried in prometheus
+          :param labels: Labels to be put inside {} of prometheus query
+        """
+        params = _params(key, labels)
+
+        response = self._do_request("/api/v1/query", params=params)
         response.raise_for_status()
         return response.json()["data"]["result"]
 
     def get_targets(self) -> dict:
         """Get active targets information"""
 
-        params = {
-            "state": "active",
-        }
+        params = {"state": "active"}
 
-        response = requests.get(f"{self.endpoint}/api/v1/targets", params=params)
+        response = self._do_request("/api/v1/targets", params=params)
         response.raise_for_status()
         return response.json()["data"]["activeTargets"]
 
-    def has_metric(self, metric: str, trigger_request: Optional[Callable] = None) -> bool:
+    def has_metric(self, metric: str, target: str = "", trigger_request: Optional[Callable] = None) -> bool:
         """
         Returns true if the given metric is collected by the current settings
         of prometheus.
         Args:
             :param metric: the name of the metric to test
-            :param trigger_request: a function triggering the metric,
-            as it does not have to be always present in Prometheus.
-            (e. g. fresh install)
-            When empty, the trigger call is not invoked.
-        """
-        try:
-            _has_metric = self.get_metric(metric) != []
-            if not _has_metric and trigger_request is not None:
-                # when testing on a new install, the metric does not have to be present
-                trigger_request()
-                # waits to refresh the prometheus metrics
-                time.sleep(PROMETHEUS_REFRESH + 2)
-                _has_metric = self.get_metric(metric) != []
-
-        except requests.exceptions.HTTPError:
-            _has_metric = False
-
-        return _has_metric
-
-    def has_metrics(self, metric: str, target: str, trigger_request: Optional[Callable] = None) -> bool:
-        """
-        Returns true if the given metric is collected by the current settings
-        of prometheus, with the selector 'container=$target'.
-        Args:
-            :param metric: the name of the metric to test
             :param target: the name of the container label
             :param trigger_request: a function triggering the metric,
-            as it does not have to be always present in Prometheus.
-            (e. g. fresh install)
+            as it does not have to be always present in Prometheus (e. g. fresh install).
             When empty, the trigger call is not invoked.
         """
+        labels = None
+        if target:
+            labels = {"container": target}
         try:
-            _has_metric = metric in self.get_metrics(target)
-            if not _has_metric and trigger_request is not None:
+            has_metric = len(self.get_metrics(key=metric, labels=labels)) > 0
+            if not has_metric and trigger_request is not None:
                 # when testing on a new install, the metric does not have to be present
                 trigger_request()
                 # waits to refresh the prometheus metrics
-                self.wait_on_next_scrape(target)
-                _has_metric = metric in self.get_metrics(target)
+                if target:
+                    self.wait_on_next_scrape(target)
+                else:
+                    time.sleep(PROMETHEUS_REFRESH + 2)
+                has_metric = len(self.get_metrics(key=metric, labels=labels)) > 0
 
         except requests.exceptions.HTTPError:
-            _has_metric = False
+            has_metric = False
 
-        return _has_metric
+        return has_metric
 
     def wait_on_next_scrape(self, target_container: str, after: Optional[datetime] = None):
         """Block until next scrape for a container is finished"""
@@ -127,12 +127,13 @@ class PrometheusClient:
         def _time_of_scrape():
             for target in self.get_targets():
                 if "container" in target["labels"].keys() and target["labels"]["container"] == target_container:
-                    return datetime.fromisoformat(target["lastScrape"][:19])
-            return None
+                    return datetime.fromisoformat(target["lastScrape"][:19]), datetime.strptime(
+                        target["discoveredLabels"]["__scrape_interval__"], "%Ss").second
+            return None, PROMETHEUS_REFRESH
 
-        last_scrape = _time_of_scrape()
+        last_scrape, scrape_interval = _time_of_scrape()
 
-        till = after + timedelta(seconds=PROMETHEUS_REFRESH + 2)
+        till = after + timedelta(seconds=scrape_interval + 2)
 
         if last_scrape:
             if after < last_scrape:
@@ -147,7 +148,7 @@ class PrometheusClient:
 
         @backoff.on_predicate(backoff.fibo, lambda x: not x, max_tries=10, jitter=None)
         def _wait_on_next_scrape():
-            _last_scrape = _time_of_scrape()
+            _last_scrape, _ = _time_of_scrape()
             if _last_scrape is not None:
                 return after < _last_scrape
             return False

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -898,8 +898,10 @@ def prometheus(testconfig, openshift):
         return PrometheusClient(testconfig["prometheus"]["url"])
 
     routes = openshift().routes.for_service('prometheus-operated')
+    operator_based = True
     if len(routes) == 0:
         routes = openshift().routes.for_service('prometheus')
+        operator_based = False
 
     if len(routes) == 0:
         warn_and_skip("Prometheus is not present in this project. Prometheus tests have been skipped.")
@@ -907,4 +909,4 @@ def prometheus(testconfig, openshift):
     protocol = "https://" if "tls" in routes[0]["spec"] else "http://"
     prometheus_url = protocol + routes[0]['spec']['host']
 
-    return PrometheusClient(prometheus_url)
+    return PrometheusClient(prometheus_url, operator_based=operator_based)

--- a/testsuite/tests/prometheus/apicast/conftest.py
+++ b/testsuite/tests/prometheus/apicast/conftest.py
@@ -10,10 +10,10 @@ def check_availability(prometheus):
     Checks whether is the prometheus configured to run tests in this module.
     """
 
-    if not prometheus.has_metrics("worker_process", "apicast-staging"):
+    if not prometheus.has_metric("worker_process", "apicast-staging"):
         warn_and_skip("The Prometheus is not configured to run this test. The collection"
                       " of basic metrics is not set up. The test has been skipped.")
 
-    if not prometheus.has_metrics("worker_process", "apicast-production"):
+    if not prometheus.has_metric("worker_process", "apicast-production"):
         warn_and_skip("The Prometheus is not configured to run this test. The collection"
                       " of basic metrics is not set up. The test has been skipped.")

--- a/testsuite/tests/prometheus/apicast/selfmanaged/conftest.py
+++ b/testsuite/tests/prometheus/apicast/selfmanaged/conftest.py
@@ -16,11 +16,10 @@ def require_openshift(testconfig):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def require_prometheus_operator(openshift):
+def require_prometheus_operator(prometheus):
     """require configured operator for prometheus"""
-    routes = openshift().routes.for_service('prometheus-operated')
-    if len(routes) == 0:
-        warn_and_skip("This test needs prometheus deployed by operator")
+    if not prometheus.operator_based:
+        warn_and_skip("This test needs prometheus deployed by operator or OpenShift user workload monitoring")
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/prometheus/apicast/selfmanaged/test_batching_caching_policy.py
+++ b/testsuite/tests/prometheus/apicast/selfmanaged/test_batching_caching_policy.py
@@ -7,6 +7,7 @@ import pytest
 from packaging.version import Version  # noqa # pylint: disable=unused-import
 from testsuite import APICAST_OPERATOR_VERSION, rawobj  # noqa # pylint: disable=unused-import
 from testsuite.capabilities import Capability
+from testsuite.prometheus import get_metrics_keys
 
 pytestmark = [
     pytest.mark.nopersistence,
@@ -26,6 +27,35 @@ def service(service):
     return service
 
 
+def pod_monitor_object_definition(apicast_deployment, namespace, apicast_operator_namespace=""):
+    """Return PodMonitor yaml definition"""
+    selector_text = ""
+    if apicast_operator_namespace:
+        selector_text = ("  namespaceSelector:\n"
+                         "    matchNames:\n"
+                         f"    - {apicast_operator_namespace}\n")
+
+    return f"""apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: apicast-selfmanaged-{apicast_deployment}
+  namespace: {namespace}
+  labels:
+    app: 3scale-api-management
+    threescale_component: apicast
+    threescale_component_element: staging
+spec:
+{selector_text}
+  podMetricsEndpoints:
+    - path: /metrics
+      port: metrics
+      scheme: http
+  selector:
+    matchLabels:
+      deployment: {apicast_deployment}
+"""
+
+
 @pytest.fixture(scope="module")
 def pod_monitor(prometheus, openshift, staging_gateway):
     """ define pod monitor for prometheus """
@@ -37,33 +67,21 @@ def pod_monitor(prometheus, openshift, staging_gateway):
     openshift_client = openshift()
     namespace = openshift_client.project_name
 
-    apicast_obj = openshift_client.create(f"""apiVersion: monitoring.coreos.com/v1
-kind: PodMonitor
-metadata:
-  name: apicast-selfmanaged-{apicast_deployment}
-  namespace: {namespace}
-  labels:
-    app: 3scale-api-management
-    threescale_component: apicast
-    threescale_component_element: staging
-spec:
-  namespaceSelector:
-    matchNames:
-    - {apicast_operator_namespace}
-  podMetricsEndpoints:
-    - path: /metrics
-      port: metrics
-      scheme: http
-  selector:
-    matchLabels:
-      deployment: {apicast_deployment}
-        """)
+    #  object in 3scale namespace (for prometheus deployed by free-deployer)
+    pod_monitor_3scale_namespace = openshift_client.create(
+        pod_monitor_object_definition(apicast_deployment, namespace, apicast_operator_namespace))
 
+    #  object in apicast operator namespace (for openshift user workload monitoring)
+    pod_monitor_apicast_namespace = openshift_client.create(
+        pod_monitor_object_definition(apicast_deployment, apicast_operator_namespace))
+
+    #  wait a little more so operator will get this config and have time to do a first scrape
     prometheus.wait_on_next_scrape(apicast_deployment, datetime.utcnow() + timedelta(seconds=60))
 
     yield
 
-    apicast_obj.delete()
+    pod_monitor_3scale_namespace.delete()
+    pod_monitor_apicast_namespace.delete()
 
 
 # pylint: disable=unused-argument
@@ -72,8 +90,11 @@ def test_batcher_policy(prometheus, pod_monitor, api_client, staging_gateway, ap
     client = api_client()
 
     apicast_deployment = staging_gateway.deployment.name
+    labels = {"namespace": staging_gateway.openshift.project_name, "container": apicast_deployment}
 
-    metrics_keys = prometheus.get_metrics(apicast_deployment)
+    prometheus.wait_on_next_scrape(apicast_deployment)
+
+    metrics_keys = get_metrics_keys(prometheus.get_metrics(labels=labels))
 
     assert "batching_policy_auths_cache_hits" not in metrics_keys
     assert "batching_policy_auths_cache_misses" not in metrics_keys
@@ -82,23 +103,24 @@ def test_batcher_policy(prometheus, pod_monitor, api_client, staging_gateway, ap
         client.get("/get")
 
     prometheus.wait_on_next_scrape(apicast_deployment, datetime.utcnow() + timedelta(seconds=BATCH_REPORT_SECONDS))
-    metrics_keys = prometheus.get_metrics(apicast_deployment)
+    metrics_keys = get_metrics_keys(prometheus.get_metrics(labels=labels))
 
     assert "batching_policy_auths_cache_hits" in metrics_keys
     assert "batching_policy_auths_cache_misses" in metrics_keys
 
-    hits, misses = get_batching_metrics(prometheus, apicast_deployment)
+    hits, misses = get_batching_metrics(prometheus, apicast_deployment, staging_gateway.openshift.project_name)
 
-    assert int(hits) == NUM_OF_REQUESTS - 1
-    assert int(misses) == 1
+    assert (int(hits), int(misses)) == (NUM_OF_REQUESTS-1, 1)
 
 
-def get_batching_metrics(prometheus, apicast_deployment):
+def get_batching_metrics(prometheus, apicast_deployment, namespace):
     """ extract hits and misses count from prometheus """
-    hits_metrics = prometheus.get_metric("batching_policy_auths_cache_hits")
-    misses_metrics = prometheus.get_metric("batching_policy_auths_cache_misses")
+    hits_metrics = prometheus.get_metrics("batching_policy_auths_cache_hits",
+                                          {"namespace": namespace, "container": apicast_deployment})
+    misses_metrics = prometheus.get_metrics("batching_policy_auths_cache_misses",
+                                            {"namespace": namespace, "container": apicast_deployment})
 
-    hits = [m for m in hits_metrics if m['metric']['container'] == apicast_deployment][0]['value'][1]
-    misses = [m for m in misses_metrics if m['metric']['container'] == apicast_deployment][0]['value'][1]
+    hits = hits_metrics[0]['value'][1]
+    misses = misses_metrics[0]['value'][1]
 
     return hits, misses

--- a/testsuite/tests/prometheus/apicast/test_content_caching_policy.py
+++ b/testsuite/tests/prometheus/apicast/test_content_caching_policy.py
@@ -7,6 +7,7 @@ import pytest
 
 from packaging.version import Version  # noqa # pylint: disable=unused-import
 from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
+from testsuite.prometheus import get_metrics_keys
 
 pytestmark = [
     pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
@@ -48,13 +49,15 @@ def test_content_caching(request, prometheus, client, apicast):
     client = request.getfixturevalue(client)()
     # """Hit apicast so that we can have metrics from it and that we can cache incoming requests"""
     # """Apicast needs to load configuration in order to cache incoming requests"""
-    client.get("/get", headers=origin_localhost)
+    response = client.get("/get", headers=origin_localhost)
+    assert response.status_code == 200
+    assert response.headers.get("X-Cache-Status") != "HIT"
 
     @backoff.on_predicate(backoff.fibo, lambda x: not x, max_tries=10, jitter=None)
     def wait():
         """Wait until content_caching key is in prometheus"""
         prometheus.wait_on_next_scrape(apicast)
-        metrics = prometheus.get_metrics(apicast)
+        metrics = get_metrics_keys(prometheus.get_metrics(labels={"container": apicast}))
         return "content_caching" in metrics
 
     wait()
@@ -72,7 +75,7 @@ def test_content_caching(request, prometheus, client, apicast):
     # prometheus is downloading metrics periodicity, we need to wait for next fetch
     prometheus.wait_on_next_scrape(apicast)
 
-    metrics = prometheus.get_metrics(apicast)
+    metrics = get_metrics_keys(prometheus.get_metrics(labels={"container": apicast}))
     assert "content_caching" in metrics
 
     counts_after = extract_caching(prometheus, "content_caching", apicast)
@@ -85,12 +88,9 @@ def extract_caching(prometheus, query, apicast):
     Given a prometheus query, returns dict with response
     codes and counts associated with the response code
     """
-    metric_response_codes = prometheus.get_metric(query)
+    metric_response_codes = prometheus.get_metrics(query, {"container": apicast})
     key_value_map = {'EXPIRED': 0, 'HIT': 0, 'MISS': 0}
     for response_code_metric in metric_response_codes:
-        if apicast != response_code_metric['metric']['container']:
-            continue
-
         key_value_map[response_code_metric['metric']['status']] \
             = response_code_metric['value'][1]
     return key_value_map

--- a/testsuite/tests/prometheus/apicast/test_metric_worker_starts.py
+++ b/testsuite/tests/prometheus/apicast/test_metric_worker_starts.py
@@ -17,24 +17,28 @@ def test_metric_worker(prometheus, production_gateway):
     """
     Test if metric worker counter will be increased when apicast worker is killed
     """
-    metrics = prometheus.get_metric("worker_process")
 
-    count_before = [m for m in metrics if m['metric']['container'] == 'apicast-production'][0]['value'][1]
+    ocp = production_gateway.openshift
+    pod = production_gateway.deployment.get_pods()
+    pod_name = pod.names()[0]
+
+    labels = {"container": "apicast-production"}
+    #  pod label is only propagated in operator based prometheus, in template based querying only by container is fine
+    if prometheus.operator_based:
+        labels["pod"] = pod_name
+
+    count_before = prometheus.get_metrics("worker_process", labels)[0]['value'][1]
 
     # There is no ps/top/htop in container, we need to search all processes and find out nginx: worker and kill him
     kill_worker = ('for k in /proc/[0-9]*;'
                    'do grep -i "^nginx: worker process" $k/cmdline 2>&1 >/dev/null;'
                    'if [[ $? == 0 ]]; then echo ${k##*/}; fi;'
                    'done | xargs kill -9')
-    ocp = production_gateway.openshift
-    pod = production_gateway.deployment.get_pods()
-    ocp.do_action("exec", ['-ti', pod.names()[0], "--", "/bin/sh", "-c", kill_worker])
+    ocp.do_action("exec", ['-ti', pod_name, "--", "/bin/sh", "-c", kill_worker])
 
     # prometheus is downloading metrics periodicity, we need to wait for next fetch
     prometheus.wait_on_next_scrape("apicast-production")
 
-    metrics = prometheus.get_metric("worker_process")
-
-    count_after = [m for m in metrics if m['metric']['container'] == 'apicast-production'][0]['value'][1]
+    count_after = prometheus.get_metrics("worker_process", labels)[0]['value'][1]
 
     assert int(count_after) == int(count_before) + 1

--- a/testsuite/tests/prometheus/apicast/test_metric_worker_starts.py
+++ b/testsuite/tests/prometheus/apicast/test_metric_worker_starts.py
@@ -19,8 +19,9 @@ def test_metric_worker(prometheus, production_gateway):
     """
 
     ocp = production_gateway.openshift
-    pod = production_gateway.deployment.get_pods()
-    pod_name = pod.names()[0]
+    pods = production_gateway.deployment.get_pods().objects()
+    pod = [pod for pod in pods if pod.model.status.phase == "Running"][0]
+    pod_name = pod.name()
 
     labels = {"container": "apicast-production"}
     #  pod label is only propagated in operator based prometheus, in template based querying only by container is fine

--- a/testsuite/tests/prometheus/apicast/test_metrics.py
+++ b/testsuite/tests/prometheus/apicast/test_metrics.py
@@ -8,6 +8,7 @@ from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 from testsuite.capabilities import Capability
 from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite.prometheus import get_metrics_keys
 
 pytestmark = [
     pytest.mark.required_capabilities(Capability.PRODUCTION_GATEWAY),
@@ -19,10 +20,11 @@ METRICS = [
     # TODO: test for this metrics after finding trigger for nginx error
     # "nginx_error_log",
     "nginx_http_connections", "nginx_metric_errors_total", "openresty_shdict_capacity",
-    "openresty_shdict_free_space", "threescale_backend_calls", "total_response_time_seconds",
-    "upstream_response_time_seconds", "upstream_status", "apicast_status", "worker_process",
-    "content_caching",
+    "openresty_shdict_free_space", "threescale_backend_calls", "upstream_status",
+    "apicast_status", "worker_process", "content_caching",
 ]
+
+METRICS_HISTOGRAM = ["total_response_time_seconds", "upstream_response_time_seconds"]
 
 STATUSES = [300, 418, 507]
 
@@ -31,14 +33,21 @@ STATUSES = [300, 418, 507]
 @pytest.fixture(scope="module", params=["apicast-staging", "apicast-production"])
 def metrics(request, prometheus):
     """Return all metrics from target defined of staging and also production apicast."""
-    metrics = prometheus.get_metrics(request.param)
+    metrics = get_metrics_keys(prometheus.get_metrics(labels={"container": request.param}))
     return metrics
 
 
 @pytest.mark.parametrize("expected_metric", METRICS)
 def test_metrics_from_target_must_contains_apicast_metrics(expected_metric, metrics):
-    """Metrics must contains expected apicast metrics defined in METRICS."""
+    """Metrics must contain expected apicast metrics defined in METRICS."""
     assert expected_metric in metrics
+
+
+@pytest.mark.parametrize("expected_metric", METRICS_HISTOGRAM)
+def test_metrics_from_target_must_contains_apicast_metrics_histogram(expected_metric, metrics):
+    """Metrics must contain expected apicast metrics defined in METRICS."""
+    for suffix in ["_bucket", "_sum", "_count"]:
+        assert expected_metric+suffix in metrics
 
 
 # there is certain delay before all appears in Prometheus
@@ -48,12 +57,12 @@ def apicast_status_metrics(prometheus, container):
 
     Metrics in prometheus appear with some delay, therefore retry is needed
     to ensure expected values are available"""
-    hits = prometheus.get_metric("apicast_status")
+    hits = prometheus.get_metrics("apicast_status", {"container": container})
 
     ret = {}
     for status in STATUSES:
         for hit in hits:
-            if int(hit["metric"]["status"]) == status and hit["metric"]["container"] == container:
+            if int(hit["metric"]["status"]) == status:
                 ret[status] = int(hit["value"][1])
     return ret
 

--- a/testsuite/tests/prometheus/backend_listener/conftest.py
+++ b/testsuite/tests/prometheus/backend_listener/conftest.py
@@ -14,9 +14,9 @@ def check_availability(prometheus, backend_listener_url):
     """
     if not prometheus.has_metric(
             "apisonator_listener_response_codes",
-            lambda: requests.get(f'{backend_listener_url}/transactions/authorize.xml')):
-        warn_and_skip("The Prometheus is not configured to run this test."
-                      " The scraping of metrics from all pods is not set up. The test has been skipped")
+            trigger_request=lambda: requests.get(f'{backend_listener_url}/transactions/authorize.xml')):
+        warn_and_skip("The Prometheus is not configured to run this test. The collection"
+                      " of basic metrics is not set up. The test has been skipped.")
 
 
 @pytest.fixture(scope="session")
@@ -43,8 +43,8 @@ def prometheus_response_codes_for_metric(prometheus):
     Given a prometheus query, returns dict with response
     codes and counts associated with the response code
     """
-    def response_codes_for_metric(query):
-        metric_response_codes = prometheus.get_metric(query)
+    def response_codes_for_metric(key, labels):
+        metric_response_codes = prometheus.get_metrics(key, labels)
         response_codes_count = {}
         for response_code_metric in metric_response_codes:
             response_codes_count[response_code_metric['metric']['resp_code']] \

--- a/testsuite/tests/prometheus/backend_listener/test_backend_worker_report_jobs.py
+++ b/testsuite/tests/prometheus/backend_listener/test_backend_worker_report_jobs.py
@@ -34,14 +34,14 @@ def auth_data(service, service_token, application):
 
 
 @pytest.fixture(scope="module")
-def prometheus_worker_job_count(prometheus, testconfig):
+def prometheus_worker_job_count(prometheus):
     """
-    Given a type of a worker job (ReportJob or NotifyJob), returns the value of that metric
+    Given a type of worker job (ReportJob or NotifyJob), returns the value of that metric
     """
     def _prometheus_worker_job_count(job_type):
-        metric_response_codes = prometheus.get_metric(
-            f"apisonator_worker_job_count{{namespace=\"{testconfig['openshift']['projects']['threescale']['name']}\", "
-            f"type=\"{job_type}\"}}")
+        metric_response_codes = prometheus.get_metrics("apisonator_worker_job_count", {
+                    "type": job_type
+                })
         return int(metric_response_codes[0]['value'][1]) if len(metric_response_codes) > 0 else 0
     return _prometheus_worker_job_count
 

--- a/testsuite/tests/prometheus/system/conftest.py
+++ b/testsuite/tests/prometheus/system/conftest.py
@@ -10,7 +10,6 @@ def check_availability(prometheus):
     Checks whether is the prometheus configured to run tests in this module.
     """
 
-    if not prometheus.has_metric(
-            "rails_requests_total"):
+    if not prometheus.has_metric("rails_requests_total"):
         warn_and_skip("The Prometheus is not configured to run this test. The collection"
                       " of basic metrics is not set up. The test has been skipped.")

--- a/testsuite/tests/prometheus/system/test_internal_calls.py
+++ b/testsuite/tests/prometheus/system/test_internal_calls.py
@@ -8,6 +8,7 @@ import requests
 
 from packaging.version import Version  # noqa # pylint: disable=unused-import
 from testsuite import TESTED_VERSION, rawobj  # noqa # pylint: disable=unused-import
+from testsuite.prometheus import get_metrics_keys
 
 pytestmark = [
     pytest.mark.disruptive,
@@ -47,13 +48,16 @@ def auth_headers(backend_internal_api_token):
 
 
 @pytest.mark.flaky
-@pytest.mark.parametrize("url", ("{}/internal/services/{}/stats/",
+@pytest.mark.parametrize("url", ("{}/internal/services/{}/stats",
                                  "{}/internal/services/{}/plans/{}/usagelimits",
                                  "{}/internal/services/{}/plans/{}/utilization"))
 def test_utilization(url, prometheus, application, backend_listener_url, auth_headers):
     """
     Test if cache works correctly and if prometheus contains content_caching metric.
     """
+
+    # Wait so we have the latest data
+    prometheus.wait_on_next_scrape("backend-worker")
     counts_before = extract_call_metrics(prometheus, "rails_requests_total", "system-provider",
                                          lambda x: x['metric']['controller'].startswith('admin/api'))
 
@@ -65,7 +69,7 @@ def test_utilization(url, prometheus, application, backend_listener_url, auth_he
     # prometheus is downloading metrics periodicity, we need to wait for next fetch
     prometheus.wait_on_next_scrape("backend-worker")
 
-    metrics = prometheus.get_metrics("system-provider")
+    metrics = get_metrics_keys(prometheus.get_metrics(labels={"container": "system-provider"}))
     assert "rails_requests_total" in metrics
 
     counts_after = extract_call_metrics(prometheus, "rails_requests_total", "system-provider",
@@ -74,18 +78,15 @@ def test_utilization(url, prometheus, application, backend_listener_url, auth_he
     assert counts_after == counts_before
 
 
-def extract_call_metrics(prometheus, query, container, predicat):
+def extract_call_metrics(prometheus, query, container, predicate=None):
     """
     Given a prometheus query, returns dict with response
     codes and counts associated with the response code
     """
-    metric_response_codes = prometheus.get_metric(query)
+    metric_response_codes = prometheus.get_metrics(query, {"container": container})
     key_value_map = {}
     for response_code_metric in metric_response_codes:
-        if container != response_code_metric['metric']['container']:
-            continue
-
-        if predicat is None or predicat(response_code_metric):
+        if predicate is None or predicate(response_code_metric):
             key_value_map[response_code_metric['metric']['controller']] \
                 = response_code_metric['value'][1]
     return key_value_map

--- a/testsuite/tests/prometheus/system/test_metrics.py
+++ b/testsuite/tests/prometheus/system/test_metrics.py
@@ -6,32 +6,48 @@ import pytest
 from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite.prometheus import get_metrics_keys
 
 METRICS_MASTER = [
     # new metrics introduced in THREESCALE-4743
-    'rails_request_duration_seconds', 'rails_requests_total',
-    'rails_view_runtime_seconds', 'rails_db_runtime_seconds',
+    'rails_requests_total',
+
     # existing metrics prior to THREESCALE-4743
     'sidekiq_enqueued_jobs', 'sidekiq_retry_jobs', 'sidekiq_queue_enqueued_jobs',
-    'sidekiq_queue_max_processing_time_seconds', 'sidekiq_processed_jobs_total',
+    'sidekiq_processed_jobs_total',
     'sidekiq_failed_jobs_total', 'sidekiq_workers',
     'sidekiq_processes', 'sidekiq_cron_jobs',
     'sidekiq_busy_workers', 'sidekiq_scheduled_jobs',
-    'sidekiq_dead_jobs', 'sidekiq_queue_latency_seconds'
+    'sidekiq_dead_jobs', 'sidekiq_queue_latency_seconds',
+    # most of the time its not set
+    # 'sidekiq_queue_max_processing_time_seconds',
 ]
+
+METRICS_DEVELOPER = [
+    "rails_requests_total",
+    # most of the time its not set
+    # 'sidekiq_queue_max_processing_time_seconds'
+    ]
+
+METRICS_MASTER_HISTOGRAM = ['rails_request_duration_seconds', 'rails_view_runtime_seconds', 'rails_db_runtime_seconds']
 
 METRICS_SIDEKIQ = [
     'sidekiq_jobs_executed_total',
     'sidekiq_jobs_success_total',
-    'sidekiq_job_runtime_seconds',
     'sidekiq_jobs_waiting_count',
     'sidekiq_jobs_scheduled_count',
     'sidekiq_jobs_retry_count',
     'sidekiq_jobs_dead_count',
     'sidekiq_active_processes',
     'sidekiq_active_workers_count',
+    # TODO: most of the time its not set, found out how to trigger
+    # 'sidekiq_queue_max_processing_time_seconds',
     # TODO: test for this metrics after finding trigger for failed sidekiq job
-    # 'sidekiq_jobs_failed_total'
+    # 'sidekiq_jobs_failed_total',
+]
+
+METRICS_SIDEKIQ_HISTOGRAM = [
+    'sidekiq_job_runtime_seconds',
 ]
 
 pytestmark = [
@@ -45,7 +61,15 @@ pytestmark = [
 @pytest.fixture(scope="module")
 def metrics_master(prometheus):
     """Return all metrics from target defined of system-master."""
-    metrics = prometheus.get_metrics("system-master")
+    metrics = get_metrics_keys(prometheus.get_metrics(labels={"container": "system-master"}))
+    return metrics
+
+
+# pylint: disable=unused-argument
+@pytest.fixture(scope="module")
+def metrics_developer(prometheus):
+    """Return all metrics from target defined of system-master."""
+    metrics = get_metrics_keys(prometheus.get_metrics(labels={"container": "system-developer"}))
     return metrics
 
 
@@ -53,7 +77,7 @@ def metrics_master(prometheus):
 @pytest.fixture(scope="module")
 def metrics_sidekiq(prometheus):
     """Return all metrics from target defined of system-master."""
-    metrics = prometheus.get_metrics("system-sidekiq")
+    metrics = get_metrics_keys(prometheus.get_metrics(labels={"container": "system-sidekiq"}))
     return metrics
 
 
@@ -63,7 +87,27 @@ def test_metric_master(metric, metrics_master):
     assert metric in metrics_master
 
 
+@pytest.mark.parametrize("metric", METRICS_MASTER_HISTOGRAM)
+def test_metric_master_histogram(metric, metrics_master):
+    """ Test system_metrics metric. """
+    for suffix in ["_bucket", "_sum", "_count"]:
+        assert metric+suffix in metrics_master
+
+
+@pytest.mark.parametrize("metric", METRICS_DEVELOPER)
+def test_metric_developer(metric, metrics_developer):
+    """ Test system_metrics metric. """
+    assert metric in metrics_developer
+
+
 @pytest.mark.parametrize("metric", METRICS_SIDEKIQ)
 def test_metric_sidekiq(metric, metrics_sidekiq):
-    """ Test system_metrics metric. """
+    """ Test sidekiq_metrics metric. """
     assert metric in metrics_sidekiq
+
+
+@pytest.mark.parametrize("metric", METRICS_SIDEKIQ_HISTOGRAM)
+def test_metric_sidekiq_histogram(metric, metrics_sidekiq):
+    """ Test sidekiq_metrics metric. """
+    for suffix in ["_bucket", "_sum", "_count"]:
+        assert metric+suffix in metrics_sidekiq

--- a/testsuite/tests/prometheus/zync/conftest.py
+++ b/testsuite/tests/prometheus/zync/conftest.py
@@ -10,7 +10,6 @@ def check_availability(prometheus):
     Checks whether is the prometheus configured to run tests in this module.
     """
 
-    if not prometheus.has_metric(
-            "que_workers_total"):
+    if not prometheus.has_metric("que_workers_total"):
         warn_and_skip("The Prometheus is not configured to run this test. The collection"
                       " of basic metrics is not set up. The test has been skipped.")

--- a/testsuite/tests/prometheus/zync/test_annotations.py
+++ b/testsuite/tests/prometheus/zync/test_annotations.py
@@ -19,14 +19,15 @@ ANNOTATIONS = [
 ]
 
 
-@pytest.fixture(params=['dc/zync', 'dc/zync-que'])
-def poda(request):
+@pytest.fixture(scope="module", params=['dc/zync', 'dc/zync-que'])
+def pod(request):
     """Return zync pod object."""
-    pod = openshift().deployment(request.param).get_pods().object()
+    pods = openshift().deployment(request.param).get_pods().objects()
+    pod = next(filter(lambda x: x.model.status.phase == "Running", pods))
     return pod
 
 
 @pytest.mark.parametrize("annotation", ANNOTATIONS)
-def test_annotation_zync(annotation, poda):
-    """ Test annotations of zync pod. """
-    assert poda.get_annotation(annotation) is not None
+def test_annotation_zync(annotation, pod):
+    """ Test annotations of zync/zync-que pod. """
+    assert pod.get_annotation(annotation) is not None

--- a/testsuite/tests/prometheus/zync/test_metrics.py
+++ b/testsuite/tests/prometheus/zync/test_metrics.py
@@ -6,6 +6,7 @@ import pytest
 from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
+from testsuite.prometheus import get_metrics_keys
 
 pytestmark = [
     pytest.mark.sandbag,  # requires openshift
@@ -14,17 +15,25 @@ pytestmark = [
 ]
 
 METRICS_QUE = [
-    "que_job_duration_seconds",
     "que_job_enqueued_total",
     "que_job_failures_total",
     "que_job_performed_total",
     "que_job_retries_total",
-    "que_job_runtime_seconds",
     "que_jobs_scheduled_total",
     "que_workers_total",
     "rails_connection_pool_connections",
     "rails_connection_pool_size",
     "rails_connection_pool_waiting",
+    "que_job_enqueued_total",
+    "que_job_failures_total",
+    "que_job_performed_total",
+    "que_job_retries_total",
+    "que_job_runtime_seconds_sum",
+    "que_job_runtime_seconds_count",
+]
+
+METRICS_QUE_HISTOGRAM = [
+    "que_job_duration_seconds",
 ]
 
 METRICS_ZYNC = [
@@ -32,39 +41,47 @@ METRICS_ZYNC = [
     "puma_max_threads",
     "puma_pool_capacity",
     "puma_running",
-    # "puma_workers", Not present in 2.11
-    "que_job_duration_seconds",
-    "que_job_enqueued_total",
-    "que_job_failures_total",
-    "que_job_performed_total",
-    "que_job_retries_total",
-    "que_job_runtime_seconds",
+    # "puma_workers", starts at 2.11
     "rails_connection_pool_connections",
     "rails_connection_pool_size",
     "rails_connection_pool_waiting",
-    "rails_db_runtime_seconds",
-    "rails_request_duration_seconds",
     "rails_requests_total",
+]
+
+METRICS_ZYNC_HISTOGRAM = [
     "rails_view_runtime_seconds",
+    "rails_request_duration_seconds",
+    "rails_db_runtime_seconds",
 ]
 
 
 @pytest.fixture(scope="module")
 def metrics_que(prometheus):
     """Return all metrics from target defined of zync-que."""
-    return prometheus.get_metrics("que")
+    return get_metrics_keys(prometheus.get_metrics(labels={"container": "que"}))
 
 
 @pytest.fixture(scope="module")
 def metrics_zync(prometheus):
     """Return all metrics from target defined of zync."""
-    return prometheus.get_metrics("zync")
+    return get_metrics_keys(prometheus.get_metrics(labels={"container": "zync"}))
 
 
 @pytest.mark.parametrize(("pod", "expected_metric"),
                          [("metrics_que", x) for x in METRICS_QUE] + [("metrics_zync", x) for x in METRICS_ZYNC]
                          )
 def test_metric_zync(request, expected_metric, pod):
-    """ Test metrics presense. """
+    """ Test metrics presence. """
     actual_metrics = request.getfixturevalue(pod)
     assert expected_metric in actual_metrics
+
+
+@pytest.mark.parametrize(("pod", "expected_metric"),
+                         [("metrics_que", x) for x in METRICS_QUE_HISTOGRAM] +
+                         [("metrics_zync", x) for x in METRICS_ZYNC_HISTOGRAM]
+                         )
+def test_metric_zync_histogram(request, expected_metric, pod):
+    """ Test metrics presence. """
+    actual_metrics = request.getfixturevalue(pod)
+    for suffix in ["_sum", "_count", "_bucket"]:
+        assert expected_metric+suffix in actual_metrics


### PR DESCRIPTION
This MR is allowing testsuite to look for metrics in OpenShift User workload monitoring.

First commit is refactoring Prometheus class to unify parameters of methods that calls Prometheus api. 

Later commit adds actual conftest update. Since such monitoring is cluster-wide, it may contain metrics from multiple 3scale instances, therefor Prometheus object also adds namespace to query if monitoring requires it.