### PR TITLE
Wasm authorities tests

### DIFF
--- a/testsuite/gateways/wasm/__init__.py
+++ b/testsuite/gateways/wasm/__init__.py
@@ -96,6 +96,10 @@ class WASMGateway(AbstractGateway):
         label = f"{self.label}-{service_id}"
         self.httpbin.delete_app(label, "requestauthentications")
 
+    def get_extension(self, service: Service) -> WASMExtension:
+        """Returns extension associated with service"""
+        return self.extensions[service["id"]]
+
     # pylint: disable=unused-argument, too-many-arguments
     def _create_api_client(self, application, endpoint, verify, cert=None, disable_retry_status_list=None):
         ext = self.extensions[application.service["id"]]

--- a/testsuite/tests/service_mesh/auth/conftest.py
+++ b/testsuite/tests/service_mesh/auth/conftest.py
@@ -1,7 +1,7 @@
 """Common conftest for all auth tests for ServiceMesh"""
 import pytest
 
-from testsuite.gateways.wasm import WASMGateway
+from testsuite.gateways.wasm import WASMGateway, WASMExtension
 
 
 @pytest.fixture(scope="session")
@@ -11,3 +11,9 @@ def no_auth_status_code(staging_gateway):
     if isinstance(staging_gateway, WASMGateway):
         return 403
     return 401
+
+
+@pytest.fixture(scope="module")
+def extension(staging_gateway, service) -> WASMExtension:
+    """Returns extension associated with default service"""
+    return staging_gateway.get_extension(service)

--- a/testsuite/tests/service_mesh/auth/conftest.py
+++ b/testsuite/tests/service_mesh/auth/conftest.py
@@ -1,7 +1,7 @@
 """Common conftest for all auth tests for ServiceMesh"""
 import pytest
 
-from testsuite.gateways.wasm import WASMGateway, WASMExtension
+from testsuite.gateways.wasm import WASMGateway
 
 
 @pytest.fixture(scope="session")
@@ -11,9 +11,3 @@ def no_auth_status_code(staging_gateway):
     if isinstance(staging_gateway, WASMGateway):
         return 403
     return 401
-
-
-@pytest.fixture(scope="module")
-def extension(staging_gateway, service) -> WASMExtension:
-    """Returns extension associated with default service"""
-    return staging_gateway.get_extension(service)

--- a/testsuite/tests/service_mesh/auth/wasm/test_authorities.py
+++ b/testsuite/tests/service_mesh/auth/wasm/test_authorities.py
@@ -4,76 +4,103 @@ from typing import List
 import pytest
 from testsuite.capabilities import Capability
 from testsuite.gateways.wasm import ServiceMeshHttpClient
-
+from testsuite.utils import blame
+from testsuite import rawobj
 
 pytestmark = pytest.mark.required_capabilities(Capability.SERVICE_MESH_WASM)
 
 
-@pytest.fixture(scope="module")
-def client_ingress(api_client, extension) -> ServiceMeshHttpClient:
-    """Returns api client using default ingress_url as ingress to service mesh."""
-    client: ServiceMeshHttpClient = api_client()
-    client.root_url = extension.ingress_url  # redundant, as its default, but included for better readability
-    return client
+@pytest.fixture(scope="function")
+# pylint: disable=too-many-arguments
+def custom_extension_and_app(custom_service, custom_app_plan, custom_application,
+                             lifecycle_hooks, request, staging_gateway):
+    """
+    Custom extension with new service, app_plan and application.
+    Returns extension and application for use in constructing api_client.
+    """
+    service = custom_service({"name": blame(request, "svc")}, hooks=lifecycle_hooks)
+    plan = custom_app_plan(rawobj.ApplicationPlan(blame(request, "plan")), service=service)
+    app = custom_application(rawobj.Application(blame(request, "app"), plan), hooks=lifecycle_hooks)
+    extension = staging_gateway.get_extension(service)
+    return extension, app
 
 
 @pytest.fixture(scope="module")
-def client_alias(api_client, extension) -> ServiceMeshHttpClient:
-    """Returns api client using first alias url as ingress to service mesh."""
-    client: ServiceMeshHttpClient = api_client()
-    client.root_url = extension.ingress_alias_url
-    return client
+def get_client_ingress(api_client):
+    """Returns getter for api client using default ingress_url as ingress to service mesh."""
+    def _get_client(extension, app) -> ServiceMeshHttpClient:
+        client: ServiceMeshHttpClient = api_client(app)
+        client.root_url = extension.ingress_url  # default, but included for readability
+        return client
+    return _get_client
 
 
-def test_alias(extension, client_ingress, client_alias):
+@pytest.fixture(scope="module")
+def get_client_alias(api_client):
+    """Returns getter for api client using service alias url as ingress to service mesh."""
+    def _get_client_alias(extension, app) -> ServiceMeshHttpClient:
+        client: ServiceMeshHttpClient = api_client(app)
+        client.root_url = extension.ingress_alias_url
+        return client
+    return _get_client_alias
+
+
+def test_alias(custom_extension_and_app, get_client_ingress, get_client_alias):
     """This test sets extension authorities to only accept alias host."""
+    extension, app = custom_extension_and_app
     extension.replace_authorities([urlsplit(extension.ingress_alias_url).netloc])
 
-    assert client_ingress.get("/").status_code == 403
-    assert client_alias.get("/").status_code == 200
+    assert get_client_ingress(extension, app).get("/").status_code == 403
+    assert get_client_alias(extension, app).get("/").status_code == 200
 
 
-def test_both(extension, client_ingress, client_alias):
+def test_both(custom_extension_and_app, get_client_ingress, get_client_alias):
     """This test sets extension authorities to accept both alias and ingress host."""
+    extension, app = custom_extension_and_app
     extension.replace_authorities(
         [urlsplit(extension.ingress_alias_url).netloc, urlsplit(extension.ingress_url).netloc])
-    assert client_ingress.get("/").status_code == 200
-    assert client_alias.get("/").status_code == 200
+    assert get_client_ingress(extension, app).get("/").status_code == 200
+    assert get_client_alias(extension, app).get("/").status_code == 200
 
 
-def test_empty(extension, client_ingress, client_alias):
+def test_empty(custom_extension_and_app, get_client_ingress, get_client_alias):
     """This test sets empty extension authorities so no client should succeed."""
+    extension, app = custom_extension_and_app
     extension.replace_authorities([])
 
-    assert client_ingress.get("/").status_code == 403
-    assert client_alias.get("/").status_code == 403
+    assert get_client_ingress(extension, app).get("/").status_code == 403
+    assert get_client_alias(extension, app).get("/").status_code == 403
 
 
-def test_glob_question_mark(extension, client_ingress, client_alias):
+def test_glob_question_mark(custom_extension_and_app, get_client_ingress, get_client_alias):
     """
     This test checks glob functionality in authorities string.
     Test sets url with replaced '.' character with '?' that denotes _any just one_
     Only authority host is the edited one.
     """
+    extension, app = custom_extension_and_app
+
     url: str = urlsplit(extension.ingress_url).netloc
     url = url.replace(".", "?")
 
     extension.replace_authorities([url])
-    assert client_ingress.get("/").status_code == 200
-    assert client_alias.get("/").status_code == 403
+    assert get_client_ingress(extension, app).get("/").status_code == 200
+    assert get_client_alias(extension, app).get("/").status_code == 403
 
 
 @pytest.mark.parametrize("glob", ["*", "?+"])
-def test_glob_star_plus(extension, client_ingress, client_alias, glob):
+def test_glob_star_plus(custom_extension_and_app, get_client_ingress, get_client_alias, glob):
     """
     This test checks glob functionality in authorities string.
     First test checks that clients connect when last subdomain is changed to '*'
     Second test checks the same with '?+' that is equivalent to '*'
     Only authority host is the edited one.
     """
+    extension, app = custom_extension_and_app
+
     url: List[str] = urlsplit(extension.ingress_url).netloc.split(".")
     url[0] = glob
 
     extension.replace_authorities([".".join(url)])
-    assert client_ingress.get("/").status_code == 200
-    assert client_alias.get("/").status_code == 200
+    assert get_client_ingress(extension, app).get("/").status_code == 200
+    assert get_client_alias(extension, app).get("/").status_code == 200

--- a/testsuite/tests/service_mesh/auth/wasm/test_authorities.py
+++ b/testsuite/tests/service_mesh/auth/wasm/test_authorities.py
@@ -1,0 +1,79 @@
+"""Tests wasm authorities filtering"""
+from urllib.parse import urlsplit
+from typing import List
+import pytest
+from testsuite.capabilities import Capability
+from testsuite.gateways.wasm import ServiceMeshHttpClient
+
+
+pytestmark = pytest.mark.required_capabilities(Capability.SERVICE_MESH_WASM)
+
+
+@pytest.fixture(scope="module")
+def client_ingress(api_client, extension) -> ServiceMeshHttpClient:
+    """Returns api client using default ingress_url as ingress to service mesh."""
+    client: ServiceMeshHttpClient = api_client()
+    client.root_url = extension.ingress_url  # redundant, as its default, but included for better readability
+    return client
+
+
+@pytest.fixture(scope="module")
+def client_alias(api_client, extension) -> ServiceMeshHttpClient:
+    """Returns api client using first alias url as ingress to service mesh."""
+    client: ServiceMeshHttpClient = api_client()
+    client.root_url = extension.ingress_alias_url
+    return client
+
+
+def test_alias(extension, client_ingress, client_alias):
+    """This test sets extension authorities to only accept alias host."""
+    extension.replace_authorities([urlsplit(extension.ingress_alias_url).netloc])
+
+    assert client_ingress.get("/").status_code == 403
+    assert client_alias.get("/").status_code == 200
+
+
+def test_both(extension, client_ingress, client_alias):
+    """This test sets extension authorities to accept both alias and ingress host."""
+    extension.replace_authorities(
+        [urlsplit(extension.ingress_alias_url).netloc, urlsplit(extension.ingress_url).netloc])
+    assert client_ingress.get("/").status_code == 200
+    assert client_alias.get("/").status_code == 200
+
+
+def test_empty(extension, client_ingress, client_alias):
+    """This test sets empty extension authorities so no client should succeed."""
+    extension.replace_authorities([])
+
+    assert client_ingress.get("/").status_code == 403
+    assert client_alias.get("/").status_code == 403
+
+
+def test_glob_question_mark(extension, client_ingress, client_alias):
+    """
+    This test checks glob functionality in authorities string.
+    Test sets url with replaced '.' character with '?' that denotes _any just one_
+    Only authority host is the edited one.
+    """
+    url: str = urlsplit(extension.ingress_url).netloc
+    url = url.replace(".", "?")
+
+    extension.replace_authorities([url])
+    assert client_ingress.get("/").status_code == 200
+    assert client_alias.get("/").status_code == 403
+
+
+@pytest.mark.parametrize("glob", ["*", "?+"])
+def test_glob_star_plus(extension, client_ingress, client_alias, glob):
+    """
+    This test checks glob functionality in authorities string.
+    First test checks that clients connect when last subdomain is changed to '*'
+    Second test checks the same with '?+' that is equivalent to '*'
+    Only authority host is the edited one.
+    """
+    url: List[str] = urlsplit(extension.ingress_url).netloc.split(".")
+    url[0] = glob
+
+    extension.replace_authorities([".".join(url)])
+    assert client_ingress.get("/").status_code == 200
+    assert client_alias.get("/").status_code == 200


### PR DESCRIPTION
This PR:

- Add authorities modification functions for WASM
- New fixture in conftest for default extension associated with default service
- Fix bug with missing else branch in ingress_url property
- Add ingress_alias_url property
- Add tests for authorities in WASM