### PR TITLE
Option to run all the tests in dedicated tenant

### DIFF
--- a/config/settings.yaml.tpl
+++ b/config/settings.yaml.tpl
@@ -53,6 +53,8 @@ default:
       polarion_project_id: PROJECTID
       polarion_response_myteamsname: teamname
   fixtures:
+    threescale:
+      private-tenant: False  # if true standalone tenant is created to run all the tests
     jaeger:
       url: "" # route to the jaeger-query service for the querying of traces
       config:

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -337,8 +337,13 @@ def testconfig():
 
 
 @pytest.fixture(scope="session")
-def threescale(testconfig):
+def threescale(testconfig, request):
     "Threescale client"
+
+    if weakget(testconfig)["fixtures"]["threescale"]["private-tenant"] % False:
+        custom_tenant = request.getfixturevalue("custom_tenant")
+        tenant = custom_tenant()
+        return tenant.admin_api(ssl_verify=testconfig["ssl_verify"], wait=0)
 
     return client.ThreeScaleClient(
         testconfig["threescale"]["admin"]["url"],


### PR DESCRIPTION
By default the tests are executed on default tenant or on that provided
by config.

Since now there is the option to run the tests on new/fresh tenant that
is created at the beginning of run and deleted at the end.

This covers the cases when custom tenant creation is covered by all the
tests or if it is easier to get master token than admin token (typically
true on deployments where a tenant for testing purposes is not present).

A caveat is that the testsuite creates as many tenant as many "threads"
are used to run it ('-n' option of xdist).
