### PR TITLE
apicast_operator: skip tests if no operator is found

### DIFF
--- a/testsuite/tests/apicast_operator/conftest.py
+++ b/testsuite/tests/apicast_operator/conftest.py
@@ -3,6 +3,7 @@
 import pytest
 
 from testsuite import settings
+from testsuite.utils import warn_and_skip
 
 
 @pytest.fixture(scope="session")
@@ -14,9 +15,13 @@ def operator(openshift):
 
     project_name = settings["threescale"]["gateway"]["OperatorApicast"]['openshift']['project_name']
 
-    pod = openshift(project=project_name, server="OperatorApicast")\
+    pod = openshift(project='openshift-operators', server="OperatorApicast")\
         .select_resource("pods", narrow_function=select_operator)
-    if not pod.object_list:
-        pod = openshift(project='openshift-operators', server="OperatorApicast")\
+    if project_name and not pod.object_list:
+        pod = openshift(project=project_name, server="OperatorApicast")\
             .select_resource("pods", narrow_function=select_operator)
+
+    if not pod.object_list:
+        warn_and_skip("Apicast operator not found. skipping tests/apicast_operator")
+
     return pod.object()


### PR DESCRIPTION
There can be only one Apicast Operator, so checking cluster-wide location first.