### PR TITLE
Eliminate few mypy warnings (types inside untyped function)

### DIFF
--- a/testsuite/gateways/service_mesh/__init__.py
+++ b/testsuite/gateways/service_mesh/__init__.py
@@ -17,7 +17,7 @@ class ServiceMeshGateway(AbstractGateway):
 
     CAPABILITIES = {Capability.SERVICE_MESH}
 
-    def __init__(self, openshift, httpbin, mesh, portal_endpoint):
+    def __init__(self, openshift, httpbin, mesh, portal_endpoint) -> None:
         self.env_vars: Dict[str, str] = {}
         self.identifier = generate_tail()
         self.openshift = openshift

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -27,7 +27,6 @@ from testsuite.openshift.client import OpenShiftClient
 from testsuite.prometheus import PrometheusClient
 from testsuite.httpx import HttpxHook
 from testsuite.mockserver import Mockserver
-from testsuite.rhsso.objects import Realm
 from testsuite.toolbox import toolbox
 from testsuite.utils import blame, blame_desc, warn_and_skip
 from testsuite.rhsso import RHSSOServiceConfiguration, RHSSO
@@ -499,7 +498,7 @@ def rhsso_service_info(request, testconfig, tools):
     rhsso = RHSSO(server_url=tools["no-ssl-sso"],
                   username=cnf["username"],
                   password=cnf["password"])
-    realm: Realm = rhsso.create_realm(blame(request, "realm"), accessTokenLifespan=24*60*60)
+    realm = rhsso.create_realm(blame(request, "realm"), accessTokenLifespan=24*60*60)
 
     if not testconfig["skip_cleanup"]:
         request.addfinalizer(realm.delete)

--- a/testsuite/tests/performance/conftest.py
+++ b/testsuite/tests/performance/conftest.py
@@ -65,7 +65,7 @@ def shared_template(testconfig, number_of_agents):
     if weakget(testconfig)["hyperfoil"]["shared_template"] % False:
         shared_template = testconfig.get('hyperfoil', {}).get('shared_template', {}).to_dict()
     else:
-        shared_template: dict = {'agents': {}}
+        shared_template = {'agents': {}}
         for i in range(1, number_of_agents + 1):
             agent = {'host': 'localhost', 'port': 22, 'stop': True}
             shared_template['agents'][f'agent-{i}'] = agent

--- a/testsuite/tests/ui/policies/test_policies.py
+++ b/testsuite/tests/ui/policies/test_policies.py
@@ -144,7 +144,7 @@ def test_edit_policy_widgets(login, navigator, policy_service, api_client, polic
     configuration_page = navigator.navigate(ProductConfigurationView, product=policy_service)
     configuration_page.configuration.staging_promote_btn.click()
 
-    policies: list = policy_service.proxy.list()["policies_config"]
+    policies = policy_service.proxy.list()["policies_config"]
     assert len(policies) == 2
     url_rewriting_policy = policies[1]
 


### PR DESCRIPTION
Add at least minimum type to function definition.
Remove types from tests/conftests, keep it in libraries.
