### PR TITLE
Better fix for use-dict-literal pylint warnings

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -18,7 +18,6 @@ disable=duplicate-code,  # reports false alarms AND can't be disabled locally; p
 	consider-using-f-string,  # % string operator is absolutely fine
         redefined-outer-name,
         missing-timeout,  # socket timeout is set globally, no need to specify it in calls
-        use-dict-literal
 
 [FORMAT]
 # Maximum number of characters on a single line.

--- a/testsuite/tests/apicast/parameters/apicast_path_routing/test_apicast_path_routing_query.py
+++ b/testsuite/tests/apicast/parameters/apicast_path_routing/test_apicast_path_routing_query.py
@@ -44,7 +44,7 @@ def test_args(client2):
     """
     Checks that request with query param will match mapping rule
     """
-    response = client2.get('/anything/foo', params=dict(baz='baz'))
+    response = client2.get('/anything/foo', params={"baz": "baz"})
 
     assert response.status_code == 200
 

--- a/testsuite/tests/apicast/parameters/policies/test_content_caching_policy_parameters.py
+++ b/testsuite/tests/apicast/parameters/policies/test_content_caching_policy_parameters.py
@@ -110,8 +110,10 @@ def client2(application2, api_client):
 
 def test_wont_cache(client, private_base_url):
     """Test that redirected request (302 status code) will not be cached"""
+    origin_localhost = {"origin": "localhost"}
+
     payload = {'url': f'{private_base_url("echo_api")}/uuid'}
-    response = client.get("/httpbin/redirect-to", params=payload, headers=dict(origin="localhost"))
+    response = client.get("/httpbin/redirect-to", params=payload, headers=origin_localhost)
     # First request was redirected
     assert response.history[0].status_code == 302
     assert response.status_code == 200
@@ -119,7 +121,7 @@ def test_wont_cache(client, private_base_url):
     echoed_request = EchoedRequest.create(response)
 
     # wont cache redirect request
-    response = client.get("/httpbin/redirect-to", params=payload, headers=dict(origin="localhost"))
+    response = client.get("/httpbin/redirect-to", params=payload, headers=origin_localhost)
     # First request was redirected
     assert response.history[0].status_code == 302
     assert response.status_code == 200
@@ -134,12 +136,14 @@ def test_will_cache(client, client2):
     """
     Test that requests will be cached with status code 200 and the cache will expire after 30 seconds
     """
-    response = client.get("/echo-api/uuid", headers=dict(origin="localhost"))
+    origin_localhost = {"origin": "localhost"}
+
+    response = client.get("/echo-api/uuid", headers=origin_localhost)
     assert response.status_code == 200
     assert response.headers.get("X-Cache-Status") != "HIT"
     echoed_request = EchoedRequest.create(response)
 
-    response = client.get("/echo-api/uuid", headers=dict(origin="localhost"))
+    response = client.get("/echo-api/uuid", headers=origin_localhost)
     assert response.status_code == 200
     assert response.headers.get("X-Cache-Status") == "HIT"
     echoed_request_cached = EchoedRequest.create(response)
@@ -148,7 +152,7 @@ def test_will_cache(client, client2):
     assert echoed_request.json['uuid'] == echoed_request_cached.json['uuid']
 
     # another service wont hit the cache with the same request
-    response = client2.get("/echo-api/uuid", headers=dict(origin="localhost"))
+    response = client2.get("/echo-api/uuid", headers=origin_localhost)
     assert response.status_code == 200
     assert response.headers.get("X-Cache-Status") != "HIT"
 
@@ -159,7 +163,7 @@ def test_will_cache(client, client2):
     time.sleep(40)
 
     # request expired
-    response = client.get("/echo-api/uuid", headers=dict(origin="localhost"))
+    response = client.get("/echo-api/uuid", headers=origin_localhost)
     assert response.status_code == 200
     assert response.headers.get("X-Cache-Status") == "EXPIRED"
     echoed_request_new = EchoedRequest.create(response)

--- a/testsuite/tests/apicast/policy/content_caching/test_content_caching.py
+++ b/testsuite/tests/apicast/policy/content_caching/test_content_caching.py
@@ -58,47 +58,52 @@ def is_expired(response):
 
 def test_caching_working_correctly(client):
     "content caching is working correctly when matchs"
-
+    origin_localhost = {"origin": "localhost"}
     path = "/test/{0}".format(uuid.uuid4())
 
-    assert not is_hit(client.get(path, headers=dict(origin="localhost")))
+    assert not is_hit(client.get(path, headers=origin_localhost))
 
     for i in range(0, 10):
-        assert is_hit(client.get(path, headers=dict(origin="localhost"))), "Request {} didn't hit the cache".format(i)
+        assert is_hit(client.get(path, headers=origin_localhost)), "Request {} didn't hit the cache".format(i)
 
 
 def test_caching_different_urls_with_same_subpath(client):
     "content caching is doing the right thing when path/subpaths are involved"
-    assert not is_hit(client.get("/test/test", headers=dict(origin="localhost")))
-    assert is_hit(client.get("/test/test", headers=dict(origin="localhost")))
+    origin_localhost = {"origin": "localhost"}
 
-    assert not is_hit(client.get("/test", headers=dict(origin="localhost")))
-    assert is_hit(client.get("/test", headers=dict(origin="localhost")))
+    assert not is_hit(client.get("/test/test", headers=origin_localhost))
+    assert is_hit(client.get("/test/test", headers=origin_localhost))
+
+    assert not is_hit(client.get("/test", headers=origin_localhost))
+    assert is_hit(client.get("/test", headers=origin_localhost))
 
 
 def test_caching_timeouts(client):
     "Validate caching timeouts time"
+    origin_localhost = {"origin": "localhost"}
 
     path = "/test/{0}".format(uuid.uuid4())
 
-    assert not is_hit(client.get(path, headers=dict(origin="localhost")))
-    assert is_hit(client.get(path, headers=dict(origin="localhost")))
+    assert not is_hit(client.get(path, headers=origin_localhost))
+    assert is_hit(client.get(path, headers=origin_localhost))
 
     # Default timeout is 60, but timers are here, so this should be safe enough
     time.sleep(70)
 
-    assert is_expired(client.get(path, headers=dict(origin="localhost")))
-    assert is_hit(client.get(path, headers=dict(origin="localhost")))
+    assert is_expired(client.get(path, headers=origin_localhost))
+    assert is_hit(client.get(path, headers=origin_localhost))
 
 
 def test_caching_body_check(client):
     """Check same body response"""
-    response = client.get('/uuid', headers=dict(origin="localhost"))
+    origin_localhost = {"origin": "localhost"}
+
+    response = client.get('/uuid', headers=origin_localhost)
     assert response.status_code == 200
     assert response.headers.get("X-Cache-Status") != "HIT"
     echoed_request = EchoedRequest.create(response)
 
-    response = client.get('/uuid', headers=dict(origin="localhost"))
+    response = client.get('/uuid', headers=origin_localhost)
     assert response.status_code == 200
     assert response.headers.get("X-Cache-Status") == "HIT"
 

--- a/testsuite/tests/apicast/policy/cors/test_cors_max_age.py
+++ b/testsuite/tests/apicast/policy/cors/test_cors_max_age.py
@@ -28,7 +28,7 @@ def service(service):
 @pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6556")
 def test_cors_headers_if_contains_custom_max_age(api_client):
     """Request with request with allowed origin that checks for Access-Control-Max-Age"""
-    response = api_client().get("/get", headers=dict(origin="localhost"))
+    response = api_client().get("/get", headers={"origin": "localhost"})
 
     assert 'Access-Control-Max-Age' in response.headers
     assert response.headers.get('Access-Control-Max-Age') == "2500"

--- a/testsuite/tests/apicast/policy/cors/test_cors_multiple_origins.py
+++ b/testsuite/tests/apicast/policy/cors/test_cors_multiple_origins.py
@@ -41,7 +41,7 @@ def test_cors_headers_for_same_origin(api_client):
     Asserts that the "Access-Control-Allow-Origin" response header is set to the
     value of the request "origin" header.
     """
-    response = api_client().get("/get", headers=dict(origin="foo.example.com"))
+    response = api_client().get("/get", headers={"origin": "foo.example.com"})
     assert response.headers.get("Access-Control-Allow-Origin") == "foo.example.com"
 
 
@@ -50,5 +50,5 @@ def test_cors_headers_for_disallowed_origin(api_client):
     Sends a url in "origin" header not matching the regex.
     Asserts that the "Access-Control-Allow-Origin" response header is not set by the policy
     """
-    response = api_client().get("/get", headers=dict(origin="disallowed.example.com"))
+    response = api_client().get("/get", headers={"origin": "disallowed.example.com"})
     assert "Access-Control-Allow-Origin" not in response.headers

--- a/testsuite/tests/apicast/policy/cors/test_cors_policy.py
+++ b/testsuite/tests/apicast/policy/cors/test_cors_policy.py
@@ -27,7 +27,7 @@ def service(service):
 
 def test_cors_headers_for_same_origin(api_client):
     """Standard request"""
-    response = api_client().get("/get", headers=dict(origin="localhost"))
+    response = api_client().get("/get", headers={"origin": "localhost"})
     assert response.headers.get("Access-Control-Allow-Origin") == "localhost"
     assert response.headers.get("Access-Control-Allow-Credentials") == 'true'
 
@@ -51,5 +51,5 @@ def test_cors_headers_for_different_origin(api_client):
     Access-Control-Allow-Origin is not added to a request with origin header with
     not allowed origin
     """
-    response = api_client().get("/get", headers=dict(origin="foo.bar.example.com"))
+    response = api_client().get("/get", headers={"origin": "foo.bar.example.com"})
     assert "Access-Control-Allow-Origin" not in response.headers

--- a/testsuite/tests/apicast/policy/tls/client_validation/conftest.py
+++ b/testsuite/tests/apicast/policy/tls/client_validation/conftest.py
@@ -20,5 +20,5 @@ def policy_settings(certificates_and_code):
     certificates, _, _ = certificates_and_code
     config = []
     for certificate in certificates:
-        config.append(dict(pem_certificate=certificate.certificate))
+        config.append({"pem_certificate": certificate.certificate})
     return rawobj.PolicyConfig("tls_validation", {"whitelist": config})

--- a/testsuite/tests/apicast/policy/tls/conftest.py
+++ b/testsuite/tests/apicast/policy/tls/conftest.py
@@ -47,12 +47,12 @@ def server_authority(request, superdomain, manager):
 @pytest.fixture(scope="module")
 def staging_gateway(request, server_authority, superdomain, manager, gateway_options, gateway_environment):
     """Deploy tls apicast gateway. We need APIcast listening on https port"""
-    kwargs = dict(
-        name=blame(request, "tls-gw"),
-        manager=manager,
-        server_authority=server_authority,
-        superdomain=superdomain
-    )
+    kwargs = {
+        "name": blame(request, "tls-gw"),
+        "manager": manager,
+        "server_authority": server_authority,
+        "superdomain": superdomain
+    }
     kwargs.update(gateway_options)
     gw = gateway(kind=TLSApicast, staging=True, **kwargs)
 

--- a/testsuite/tests/apicast/policy/url_rewriting/test_url_rewriting_policy_query_arg_del.py
+++ b/testsuite/tests/apicast/policy/url_rewriting/test_url_rewriting_policy_query_arg_del.py
@@ -17,7 +17,7 @@ def policy_settings():
 
 def test_url_rewriting_policy_delete_arg_req(api_client):
     """Args should be deleted for the request"""
-    response = api_client().get("/get", params=dict(arg="old_value", arg2="value"))
+    response = api_client().get("/get", params={"arg": "old_value", "arg2": "value"})
     assert response.status_code == 200
 
     echoed_request = EchoedRequest.create(response)

--- a/testsuite/tests/apicast/policy/url_rewriting/test_url_rewriting_policy_query_arg_set.py
+++ b/testsuite/tests/apicast/policy/url_rewriting/test_url_rewriting_policy_query_arg_set.py
@@ -18,7 +18,7 @@ def policy_settings():
 
 def test_url_rewriting_policy_query_set_args(api_client):
     """Args should be rewritten for the request"""
-    response = api_client().get("/get", params=dict(arg="old_value"))
+    response = api_client().get("/get", params={"arg": "old_value"})
     assert response.status_code == 200
 
     echoed_request = EchoedRequest.create(response)

--- a/testsuite/tests/apicast/webhooks/test_webhooks_account.py
+++ b/testsuite/tests/apicast/webhooks/test_webhooks_account.py
@@ -34,7 +34,8 @@ def params(request):
     :return: params for custom account
     """
     name = blame(request, "id")
-    return dict(name=name, username=name, org_name=name, email=f"{name}@anything.invalid")
+
+    return {"name": name, "username": name, "org_name": name, "email": f"{name}@anything.invalid"}
 
 
 def test_account_created(custom_account, params, requestbin):

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -380,10 +380,14 @@ def account(custom_account, request, testconfig, account_password):
     "Preconfigured account existing over whole testing session"
     iname = blame(request, "id")
     account = rawobj.Account(org_name=iname, monthly_billing_enabled=None, monthly_charging_enabled=None)
-    account.update(dict(
-        name=iname, username=iname,
-        email=f"{iname}@example.com",
-        password=account_password))
+    account.update(
+        {
+            "name": iname,
+            "username": iname,
+            "email": f"{iname}@example.com",
+            "password": account_password,
+        }
+    )
     account = custom_account(params=account)
 
     return account
@@ -410,8 +414,12 @@ def user(custom_user, account, request, testconfig):
     "Preconfigured user existing over whole testing session"
     username = blame(request, 'us')
     domain = testconfig["threescale"]["superdomain"]
-    usr = dict(username=username, email=f"{username}@{domain}",
-               password=blame(request, ''), account_id=account['id'])
+    usr = {
+        "username": username,
+        "email": f"{username}@{domain}",
+        "password": blame(request, ""),
+        "account_id": account["id"],
+    }
     usr = custom_user(account, params=usr)
 
     return usr

--- a/testsuite/tests/custom_tenant/test_custom_tenant.py
+++ b/testsuite/tests/custom_tenant/test_custom_tenant.py
@@ -26,10 +26,14 @@ def account(custom_account, request, account_password):
     """Local module scoped account to utilize custom tenant"""
     iname = blame(request, "id")
     account = rawobj.Account(org_name=iname, monthly_billing_enabled=None, monthly_charging_enabled=None)
-    account.update(dict(
-        name=iname, username=iname,
-        email=f"{iname}@example.com",
-        password=account_password))
+    account.update(
+        {
+            "name": iname,
+            "username": iname,
+            "email": f"{iname}@example.com",
+            "password": account_password,
+        }
+    )
     account = custom_account(params=account)
 
     return account

--- a/testsuite/tests/prometheus/apicast/test_content_caching_policy.py
+++ b/testsuite/tests/prometheus/apicast/test_content_caching_policy.py
@@ -44,10 +44,11 @@ def test_content_caching(request, prometheus, client, apicast):
     """
     Test if cache works correctly and if prometheus contains content_caching metric.
     """
+    origin_localhost = {"origin": "localhost"}
     client = request.getfixturevalue(client)()
     # """Hit apicast so that we can have metrics from it and that we can cache incoming requests"""
     # """Apicast needs to load configuration in order to cache incoming requests"""
-    client.get("/get", headers=dict(origin="localhost"))
+    client.get("/get", headers=origin_localhost)
 
     @backoff.on_predicate(backoff.fibo, lambda x: not x, max_tries=10, jitter=None)
     def wait():
@@ -60,11 +61,11 @@ def test_content_caching(request, prometheus, client, apicast):
 
     counts_before = extract_caching(prometheus, "content_caching", apicast)
 
-    response = client.get("/anything/test", headers=dict(origin="localhost"))
+    response = client.get("/anything/test", headers=origin_localhost)
     assert response.status_code == 200
     assert response.headers.get("X-Cache-Status") != "HIT"
 
-    response = client.get("/anything/test", headers=dict(origin="localhost"))
+    response = client.get("/anything/test", headers=origin_localhost)
     assert response.status_code == 200
     assert response.headers.get("X-Cache-Status") == "HIT"
 

--- a/testsuite/tests/toolbox/test_application.py
+++ b/testsuite/tests/toolbox/test_application.py
@@ -20,7 +20,7 @@ def my_services(custom_service, service, request):
 def my_accounts(custom_account, account, request):
     """Accounts fixture"""
     iname = blame(request, "account")
-    return (account, custom_account(dict(name=iname, username=iname, org_name=iname)))
+    return (account, custom_account({"namd": iname, "username": iname, "org_name": iname}))
 
 
 @pytest.fixture(scope="module")
@@ -28,9 +28,15 @@ def my_account_users(request, user, custom_user, my_accounts, testconfig):
     """Account users fixture"""
     username = blame(request, 'user')
     domain = testconfig["threescale"]["superdomain"]
-    user2 = custom_user(my_accounts[1],
-                        dict(username=username, email=f"{username}@{domain}",
-                             password=blame(request, ''), account_id=my_accounts[1]['id']))
+    user2 = custom_user(
+        my_accounts[1],
+        {
+            "username": username,
+            "email": f"{username}@{domain}",
+            "password": blame(request, ""),
+            "account_id": my_accounts[1]["id"],
+        },
+    )
     return (user, user2)
 
 

--- a/testsuite/tests/toolbox/test_openapi.py
+++ b/testsuite/tests/toolbox/test_openapi.py
@@ -127,7 +127,7 @@ def account(custom_account, request, testconfig, dest_client, import_oas):
     # pylint: disable=unused-argument
     iname = blame(request, "account")
     account = rawobj.Account(org_name=iname, monthly_billing_enabled=None, monthly_charging_enabled=None)
-    account.update(dict(name=iname, username=iname, email=f"{iname}@anything.invalid"))
+    account.update({"name": iname, "username": iname, "email": f"{iname}@anything.invalid"})
     return custom_account(threescale_client=dest_client, params=account)
 
 
@@ -299,8 +299,10 @@ def test_request(import_oas, oas, rhsso_service_info, application):
     path = '/anything/products'
     if oas['type'] == 'oas3':
         # this url should be updated because of https://issues.redhat.com/browse/THREESCALE-5925
-        update_params = dict(credentials_location='authorization',
-                             oidc_issuer_endpoint=rhsso_service_info.authorization_url())
+        update_params = {
+            "credentials_location": "authorization",
+            "oidc_issuer_endpoint": rhsso_service_info.authorization_url(),
+        }
         proxy = service.proxy.list()
         proxy.update(params=update_params)
         pol = proxy.policies.list()

--- a/testsuite/tests/toolbox/test_product_update.py
+++ b/testsuite/tests/toolbox/test_product_update.py
@@ -245,13 +245,17 @@ def modify_apps_account(modify_product, request, custom_application,
     # pylint: disable=too-many-arguments
     iname = blame(request, "account")
     acc_raw = rawobj.Account(org_name=iname, monthly_billing_enabled=None, monthly_charging_enabled=None)
-    acc_raw.update(dict(name=iname, username=iname, email=f"{iname}@anything.invalid"))
+    acc_raw.update({"name": iname, "username": iname, "email": f"{iname}@anything.invalid"})
     account_up = custom_account(acc_raw)
 
     username = blame(request, 'us')
     domain = testconfig["threescale"]["superdomain"]
-    usr = dict(username=username, email=f"{username}@{domain}",
-               password=blame(request, ''), account_id=account_up['id'])
+    usr = {
+        "username": username,
+        "email": f"{username}@{domain}",
+        "password": blame(request, ""),
+        "account_id": account_up["id"],
+    }
     custom_user(account_up, params=usr)
 
     plan_silver = my_applications_plans[2]

--- a/testsuite/tests/ui/devel/auth/test_login_recaptcha.py
+++ b/testsuite/tests/ui/devel/auth/test_login_recaptcha.py
@@ -49,7 +49,7 @@ def params(request):
     """
     name = blame(request, "ui_account")
     params = rawobj.Account(name, monthly_billing_enabled=False, monthly_charging_enabled=False)
-    params.update(dict(name=name, username=name, email=f"{name}@anything.invalid"))
+    params.update({"name": name, "username": name, "email": f"{name}@anything.invalid"})
     return params
 
 

--- a/testsuite/tests/ui/devel/billing/conftest.py
+++ b/testsuite/tests/ui/devel/billing/conftest.py
@@ -18,7 +18,7 @@ def line_items():
 @pytest.fixture
 def api_invoice(account, threescale, line_items):
     """Invoice created through API"""
-    invoice = threescale.invoices.create(dict(account_id=account['id']))
+    invoice = threescale.invoices.create({"account_id": account['id']})
     for line_item in line_items:
         invoice.line_items.create(line_item)
 
@@ -96,10 +96,14 @@ def account(threescale, custom_account, request, account_password):
     """Preconfigured account existing over whole testing session"""
     iname = randomize("id")
     account = rawobj.Account(org_name=iname, monthly_billing_enabled=False, monthly_charging_enabled=False)
-    account.update(dict(
-        name=iname, username=iname,
-        email=f"{iname}@anything.invalid",
-        password=account_password))
+    account.update(
+        {
+            "name": iname,
+            "username": iname,
+            "email": f"{iname}@anything.invalid",
+            "password": account_password,
+        }
+    )
 
     def _cancel_invoices():
         """If the tests fails and the invoices are kept open, it wont remove the account until they are cancelled"""

--- a/testsuite/tests/ui/devel/test_devel_smoke.py
+++ b/testsuite/tests/ui/devel/test_devel_smoke.py
@@ -12,7 +12,7 @@ def provider_account(provider_account):
     If `site_access_code` was changed in tests, it is restored to its original value"""
     access_code = provider_account['site_access_code']
     yield provider_account
-    provider_account.update(dict(site_access_code=access_code))
+    provider_account.update({"site_access_code": access_code})
 
 
 # pylint: disable=unused-argument
@@ -41,6 +41,6 @@ def test_empty_access_code(browser, provider_account):
     browser.url = settings["threescale"]["devel"]["url"]
     assert AccessView(browser).is_displayed
 
-    provider_account.update(dict(site_access_code=""))
+    provider_account.update({"site_access_code": ""})
     browser.selenium.refresh()
     assert LandingView(browser).is_displayed

--- a/testsuite/tests/ui/search/test_account_search.py
+++ b/testsuite/tests/ui/search/test_account_search.py
@@ -55,10 +55,12 @@ def custom_account(custom_account, request):
     Parametrized custom Account
     """
     def _custom(name):
-        custom_account(dict(org_name=name,
-                            username=blame(request, "username"),
-                            email=f"{blame(request, 'email')}@anything.invalid",
-                            password="123456"))
+        custom_account({
+            "org_name": name,
+            "username": blame(request, "username"),
+            "email": f"{blame(request, 'email')}@anything.invalid",
+            "password": "123456",
+        })
 
     return _custom
 
@@ -99,9 +101,12 @@ def test_search_non_existing_value(request, login, navigator, custom_account):
         - you search account by non-existing-value it won't return anything
     """
     username = blame(request, "username")
-    params = dict(org_name=blame(request, "org_name"), username=username,
-                  email=f"{blame(request, 'email')}@anything.invalid",
-                  password="123456")
+    params = {
+        "org_name": blame(request, "org_name"),
+        "username": username,
+        "email": f"{blame(request, 'email')}@anything.invalid",
+        "password": "123456",
+    }
     custom_account(params)
 
     accounts = navigator.navigate(AccountsView)
@@ -121,9 +126,12 @@ def test_search_short_keyword(login, navigator, custom_account, request):
         - you search account by specific org_name it will return the correct one
     """
     org_name = blame(request, "org-cz")
-    params = dict(org_name=org_name, username=blame(request, "username"),
-                  email=f"{blame(request, 'email')}@anything.invalid",
-                  password="123456")
+    params = {
+        "org_name": org_name,
+        "username": blame(request, "username"),
+        "email": f"{blame(request, 'email')}@anything.invalid",
+        "password": "123456",
+    }
     custom_account(params)
     accounts = navigator.navigate(AccountsView)
 

--- a/testsuite/tests/ui/tokens/conftest.py
+++ b/testsuite/tests/ui/tokens/conftest.py
@@ -29,7 +29,7 @@ def api_client(testconfig):
 @pytest.fixture
 def invoice(threescale, account):
     """Crate invoice through API"""
-    invoice = threescale.invoices.create(dict(account_id=account['id']))
+    invoice = threescale.invoices.create({"account_id": account['id']})
 
     yield invoice
 

--- a/testsuite/tests/ui/webhooks/test_webhooks_account.py
+++ b/testsuite/tests/ui/webhooks/test_webhooks_account.py
@@ -110,7 +110,7 @@ def test_account_deleted(custom_account, requestbin, login, navigator, request):
     """
     name = blame(request, "ui_account")
     params = rawobj.Account(name, None, None)
-    params.update(dict(name=name, username=name, email=f"{name}@anything.invalid"))
+    params.update({"name": name, "username": name, "email": f"{name}@anything.invalid"})
     account = custom_account(params=params, autoclean=False)
 
     account_view = navigator.navigate(AccountEditView, account=account)

--- a/testsuite/tests/ui/webhooks/test_webhooks_user.py
+++ b/testsuite/tests/ui/webhooks/test_webhooks_user.py
@@ -85,7 +85,7 @@ def test_user_delete(login, navigator, requestbin, threescale, custom_account, r
     """
     name = blame(request, "ui_account")
     params = rawobj.Account(name, None, None)
-    params.update(dict(name=name, username=name, email=f"{name}@anything.invalid"))
+    params.update({"name": name, "username": name, "email": f"{name}@anything.invalid"})
     account = custom_account(params=params, autoclean=False)
 
     user = account.users.list()[0]


### PR DESCRIPTION
WHY WOULD ANYONE USE IT IN REQUEST HEADERS?