### PR TITLE
Add backoff to select_by_value of dropdown widget

### DIFF
--- a/testsuite/ui/widgets/__init__.py
+++ b/testsuite/ui/widgets/__init__.py
@@ -196,6 +196,7 @@ class ThreescaleDropdown(GenericLocatorWidget):
         return self.browser.selenium.find_element(By.XPATH, "//select/option[@selected='selected']") \
             .get_attribute("value")
 
+    @backoff.on_exception(backoff.fibo, NoSuchElementException, max_tries=4, jitter=None)
     def select_by_value(self, value):
         """Select given value from dropdown"""
         if value:


### PR DESCRIPTION
Some test(s) fail on this call with excetion when such item does not
exist. Might be because of quick navigation (or slow rendering). In some
environments happens regularly, in others never. Retry (as done in other
widget valls) should/could help.
