### PR TITLE
Remove superdomain from NO_PROXY

### DIFF
--- a/testsuite/tests/apicast/parameters/http_proxy/large_data/conftest.py
+++ b/testsuite/tests/apicast/parameters/http_proxy/large_data/conftest.py
@@ -30,13 +30,12 @@ def gateway_environment(gateway_environment, testconfig, tools):
     - To not load configuration every time, we set APIcast to load configuration on boot instead
     """
     rhsso_url = urlparse(tools["no-ssl-sso"]).hostname
-    superdomain = testconfig["threescale"]["superdomain"]
     proxy_endpoint = testconfig["proxy"]
 
     gateway_environment.update({"HTTP_PROXY": proxy_endpoint['http'],
                                 "HTTPS_PROXY": proxy_endpoint['https'],
                                 "NO_PROXY":
-                                    f"backend-listener,system-master,system-provider,{rhsso_url},{superdomain}",
+                                    f"backend-listener,system-master,system-provider,{rhsso_url}",
                                 "APICAST_CONFIGURATION_LOADER": "boot",
                                 "APICAST_CONFIGURATION_CACHE": 1000})
     return gateway_environment

--- a/testsuite/tests/apicast/parameters/http_proxy/test_https_proxy_extra_path.py
+++ b/testsuite/tests/apicast/parameters/http_proxy/test_https_proxy_extra_path.py
@@ -31,12 +31,11 @@ def gateway_environment(gateway_environment, testconfig, tools):
         - NO_PROXY - needed to skip proxy for internal services: system, backend, sso
     """
     rhsso_url = urlparse(tools["no-ssl-sso"]).hostname
-    superdomain = testconfig["threescale"]["superdomain"]
     https_proxy = testconfig["proxy"]["https"]
 
     gateway_environment.update({"HTTPS_PROXY": https_proxy,
                                 "NO_PROXY":
-                                    f"backend-listener,system-master,system-provider,{rhsso_url},{superdomain}"})
+                                    f"backend-listener,system-master,system-provider,{rhsso_url}"})
     return gateway_environment
 
 


### PR DESCRIPTION
superdomain was added to no_proxy in proxy tests to avoid connection
issues inside of 3scale. The idea was that superdomain is always
different from default naming scheme of openshift routes (true in our
test environment). However that is not always the case, therefore
superdomain should not be there.
