### PR TITLE
retry instead of sleep in conftest

### DIFF
--- a/testsuite/resilient.py
+++ b/testsuite/resilient.py
@@ -54,3 +54,9 @@ def accounts_create(client, params):
             client.accounts.delete(client.accounts.read_by_name(params["name"]).entity_id)
             time.sleep(2)
         raise err
+
+
+@backoff.on_exception(backoff.fibo, ApiClientError, max_tries=8, jitter=None)
+def proxy_update(svc, params):
+    """Proxy update right after service create seems failing sometimes, let's give it bit more tries"""
+    return svc.proxy.update(params=params)

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -5,7 +5,6 @@ import inspect
 import logging
 import os
 import signal
-import time
 import warnings
 
 import importlib_resources as resources
@@ -787,9 +786,6 @@ def custom_service(threescale, request, testconfig, logger):
 
             request.addfinalizer(finalizer)
 
-        # Due to asynchronous nature of 3scale the proxy is not always ready immediately,
-        # this is not necessarily bug of 3scale but we need to compensate for it regardless
-        time.sleep(1)
         if backends:
             for path, backend in backends.items():
                 svc.backend_usages.create({"path": path, "backend_api_id": backend["id"]})
@@ -802,7 +798,7 @@ def custom_service(threescale, request, testconfig, logger):
             for hook in _select_hooks("before_proxy", hooks):
                 proxy_params = hook(svc, proxy_params)
 
-            svc.proxy.update(params=proxy_params)
+            resilient.proxy_update(svc, params=proxy_params)
         svc.proxy.deploy()
 
         for hook in _select_hooks("on_service_create", hooks):


### PR DESCRIPTION
sleep shouldn't be used to mitigate delays in the app, it isn't reliable
enough. Using backoff is a practive proven to be correct.
