### PR TITLE
Make SelfManagedApicast as default for parameters tests

### DIFF
--- a/testsuite/tests/apicast/parameters/apicast_path_routing/conftest.py
+++ b/testsuite/tests/apicast/parameters/apicast_path_routing/conftest.py
@@ -2,7 +2,6 @@
 import pytest
 
 from testsuite import rawobj
-from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 from testsuite.utils import blame
 
 
@@ -11,12 +10,6 @@ def delete_all_mapping_rules(proxy):
     mapping_rules = proxy.mapping_rules.list()
     for mapping_rule in mapping_rules:
         proxy.mapping_rules.delete(mapping_rule["id"])
-
-
-@pytest.fixture(scope="module")
-def gateway_kind():
-    """Gateway class to use for tests"""
-    return SelfManagedApicast
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/conftest.py
+++ b/testsuite/tests/apicast/parameters/conftest.py
@@ -3,7 +3,7 @@ from weakget import weakget
 import pytest
 
 from testsuite.gateways import gateway
-from testsuite.gateways.apicast.template import TemplateApicast
+from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 from testsuite.utils import blame, warn_and_skip
 
 
@@ -31,7 +31,7 @@ def staging_gateway(request, gateway_kind, gateway_environment, gateway_options,
 @pytest.fixture(scope="module")
 def gateway_kind():
     """Gateway class to use for tests"""
-    return TemplateApicast
+    return SelfManagedApicast
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/filter_by_url/test_oidc_timeout_err_filter_by_url.py
+++ b/testsuite/tests/apicast/parameters/filter_by_url/test_oidc_timeout_err_filter_by_url.py
@@ -17,7 +17,6 @@ from threescale_api.resources import Service
 
 from testsuite.capabilities import Capability
 from testsuite.gateways import gateway
-from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 from testsuite.gateways.apicast.template import TemplateApicast
 from testsuite.utils import blame
 from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
@@ -26,12 +25,6 @@ pytestmark = [
     pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT),
     pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6139")]
-
-
-@pytest.fixture(scope="module")
-def gateway_kind():
-    """Gateway class to use for tests"""
-    return SelfManagedApicast
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/testsuite/tests/apicast/parameters/http_proxy/large_data/conftest.py
+++ b/testsuite/tests/apicast/parameters/http_proxy/large_data/conftest.py
@@ -4,7 +4,6 @@ from urllib.parse import urlparse
 import pytest
 
 from testsuite import rawobj
-from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 from testsuite.utils import blame
 
 
@@ -12,12 +11,6 @@ from testsuite.utils import blame
 def protocol(request):
     """Protocol which is used on http(s) service/proxy/backend"""
     return request.param
-
-
-@pytest.fixture(scope="module")
-def gateway_kind():
-    """Gateway class to use for tests"""
-    return SelfManagedApicast
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/http_proxy/test_http_proxy.py
+++ b/testsuite/tests/apicast/parameters/http_proxy/test_http_proxy.py
@@ -8,15 +8,8 @@ import pytest
 from testsuite import rawobj
 from testsuite.echoed_request import EchoedRequest
 from testsuite.capabilities import Capability
-from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 
 pytestmark = [pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT)]
-
-
-@pytest.fixture(scope="module")
-def gateway_kind():
-    """Gateway class to use for tests"""
-    return SelfManagedApicast
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/jaeger/test_jaeger_apicast_integration.py
+++ b/testsuite/tests/apicast/parameters/jaeger/test_jaeger_apicast_integration.py
@@ -6,17 +6,10 @@ It is necessary to have the jaeger url config value set
 import backoff
 import pytest
 
-from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 from testsuite.utils import randomize
 from testsuite.capabilities import Capability
 
 pytestmark = [pytest.mark.required_capabilities(Capability.JAEGER, Capability.CUSTOM_ENVIRONMENT)]
-
-
-@pytest.fixture(scope="module")
-def gateway_kind():
-    """Gateway class to use for tests"""
-    return SelfManagedApicast
 
 
 @pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-5669")

--- a/testsuite/tests/apicast/parameters/policies/test_content_caching_policy_parameters.py
+++ b/testsuite/tests/apicast/parameters/policies/test_content_caching_policy_parameters.py
@@ -11,17 +11,10 @@ import pytest
 from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.echoed_request import EchoedRequest
 from testsuite.capabilities import Capability
-from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 from testsuite.utils import blame, randomize
 
 pytestmark = [pytest.mark.skipif("TESTED_VERSION < Version('2.9')"),
               pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT)]
-
-
-@pytest.fixture(scope="module")
-def gateway_kind():
-    """Gateway class to use for tests"""
-    return SelfManagedApicast
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/test_apicast_access_log_file.py
+++ b/testsuite/tests/apicast/parameters/test_apicast_access_log_file.py
@@ -10,12 +10,19 @@ from urllib.parse import urlparse
 import pytest
 
 from testsuite.capabilities import Capability
+from testsuite.gateways.apicast.template import TemplateApicast
 
 pytestmark = [pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT),
               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6193")]
 
 
 ACCESS_LOG_FILE = "access.log"
+
+
+@pytest.fixture(scope="module")
+def gateway_kind():
+    """Use TemplateApicast as APICAST_ACCESS_LOG_FILE is not available in Operator"""
+    return TemplateApicast
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/test_apicast_load_services.py
+++ b/testsuite/tests/apicast/parameters/test_apicast_load_services.py
@@ -5,19 +5,12 @@ from packaging.version import Version  # noqa # pylint: disable=unused-import
 from testsuite import rawobj, TESTED_VERSION # noqa # pylint: disable=unused-import
 from testsuite.capabilities import Capability
 
-from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 from testsuite.utils import blame
 
 pytestmark = [
     pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-8419")
 ]
-
-
-@pytest.fixture(scope="module")
-def gateway_kind():
-    """Gateway class to use for tests"""
-    return SelfManagedApicast
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/test_apicast_service.py
+++ b/testsuite/tests/apicast/parameters/test_apicast_service.py
@@ -5,18 +5,11 @@ import pytest
 
 from testsuite import rawobj
 from testsuite.capabilities import Capability
-from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 from testsuite.utils import blame
 
 pytestmark = [
     pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-1524")]
-
-
-@pytest.fixture(scope="module")
-def gateway_kind():
-    """Gateway class to use for tests"""
-    return SelfManagedApicast
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/test_apicast_service_configuration_version.py
+++ b/testsuite/tests/apicast/parameters/test_apicast_service_configuration_version.py
@@ -8,15 +8,8 @@ import pytest
 
 from testsuite.capabilities import Capability
 from testsuite import rawobj
-from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 
 pytestmark = pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT)
-
-
-@pytest.fixture(scope="module")
-def gateway_kind():
-    """Gateway class to use for tests"""
-    return SelfManagedApicast
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/test_apicast_services_list.py
+++ b/testsuite/tests/apicast/parameters/test_apicast_services_list.py
@@ -6,16 +6,9 @@ import pytest
 
 from testsuite import rawobj
 from testsuite.capabilities import Capability
-from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 from testsuite.utils import blame
 
 pytestmark = pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT)
-
-
-@pytest.fixture(scope="module")
-def gateway_kind():
-    """Gateway class to use for tests"""
-    return SelfManagedApicast
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/test_many_oc_apicast_services.py
+++ b/testsuite/tests/apicast/parameters/test_many_oc_apicast_services.py
@@ -5,11 +5,18 @@ Then asserts that the gateway has been correctly deployed.
 import pytest
 
 from testsuite.capabilities import Capability
+from testsuite.gateways.apicast.template import TemplateApicast
 from testsuite.openshift.client import ServiceTypes
 from testsuite.utils import blame
 
 pytestmark = [pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT),
               pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6315")]
+
+
+@pytest.fixture(scope="module")
+def gateway_kind():
+    """No idea, why TemplateApicast is used here"""
+    return TemplateApicast
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/test_proxy_config.py
+++ b/testsuite/tests/apicast/parameters/test_proxy_config.py
@@ -7,7 +7,6 @@ from packaging.version import Version  # noqa # pylint: disable=unused-import
 
 from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
 from testsuite.capabilities import Capability
-from testsuite.gateways.apicast.selfmanaged import SelfManagedApicast
 
 pytestmark = [
     pytest.mark.sandbag,
@@ -15,12 +14,6 @@ pytestmark = [
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-8485"),
     pytest.mark.skipif("TESTED_VERSION < Version('2.13')")
 ]
-
-
-@pytest.fixture(scope="module")
-def gateway_kind():
-    """Gateway class to use for tests"""
-    return SelfManagedApicast
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/test_threescale_config_file.py
+++ b/testsuite/tests/apicast/parameters/test_threescale_config_file.py
@@ -8,9 +8,16 @@ import pytest
 
 from testsuite.capabilities import Capability
 from testsuite import rawobj
+from testsuite.gateways.apicast.template import TemplateApicast
 from testsuite.utils import blame
 
 pytestmark = pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT)
+
+
+@pytest.fixture(scope="module")
+def gateway_kind():
+    """Use TemplateApicast as THREESCALE_CONFIG_FILE is not available in Operator"""
+    return TemplateApicast
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
- Now TemplateApicast should be only used when needed, and it should be explained why
- I stumbled upon a few tests (e.g. `test_date_logging`), which used the implicit TemplateApicast, and they didn't need to. This should fix those cases and ensure they do not happen in the future
- Yes, it is a change that is not needed, and this PR can be scrapped if wanted