### PR TITLE
Move rate_limit_connection from disruptive to flaky

### DIFF
--- a/testsuite/tests/apicast/policy/rate_limit/test_rate_limit_connection.py
+++ b/testsuite/tests/apicast/policy/rate_limit/test_rate_limit_connection.py
@@ -37,7 +37,9 @@ from testsuite.httpx import AsyncClientHook
 from testsuite.utils import randomize, blame
 
 
-pytestmark = pytest.mark.disruptive
+# the results can be bit unstable due to higher load caused by parallel
+# http requests
+pytestmark = pytest.mark.flaky
 
 TOTAL_REQUESTS = 20
 CONNECTIONS = 10


### PR DESCRIPTION
rate_limit_connection still suffers from unexpected failures. Another
retry made by flaky can be helpful.
