### PR TITLE
Just chars numbers from version in project

### DIFF
--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -202,7 +202,7 @@ def pytest_metadata(metadata):
         "polarion-response-myteamsname":
             _settings["reporting"]["testsuite_properties"]["polarion_response_myteamsname"] % "None",
         "polarion-lookup-method": "name",
-        "project": "3scale-" + str(version).replace(".", "")[:4],
+        "project": "3scale-" + str(version).replace(".", "")[:3],
     })
 
     if Capability.OCP4 in CapabilityRegistry():


### PR DESCRIPTION
Project is a key supposed to be used in reportportal as project name and
for now use of just major & minor numbers is enough.
