### PR TITLE
OperatorApicast is forced option for SelfManagedApicast

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -9,6 +9,8 @@ default:
         echo_api: https://echo-api.3scale.net:443
         httpbin_nossl: http://httpbin.org:80
     gateway:
+      SelfManagedApicast:
+        force: OperatorApicast
       TemplateApicast:
         template: apicast.yml
       WASMGateway:


### PR DESCRIPTION
SelfManagedApicast has been designed to choose correct apicast
deployment method. Nowadays TemplateApicast is obsolete and unexpected
use in case of operator based deployment testing.

Let's force it via config for now as this is desired state. The
functionality remains included as well as posibility to overwrite it by
user (though swith to default auto-choose behavior could be bit
difficult via settings).
