### PR TITLE
Unify operator and subscription methods in OpenShfitClient

### DIFF
--- a/testsuite/dynaconf_loader.py
+++ b/testsuite/dynaconf_loader.py
@@ -78,7 +78,7 @@ def _guess_apicast_operator_version(ocp, settings):
         return 0
     version = None
     try:
-        version = ocp.apicast_operator_subscription.object().model.status.installedCSV.split(".v")[1]
+        version = ocp.apicast_operator_subscription.model.status.installedCSV.split(".v")[1]
         version = version.split("-")[0]
         Version(version)
     except (ValueError, IndexError, OpenShiftPythonException, InvalidVersion):
@@ -86,7 +86,7 @@ def _guess_apicast_operator_version(ocp, settings):
         try:
             _ocp = _apicast_ocp(ocp, settings)
             _ocp.project_name = "openshift-operators"
-            version = _ocp.apicast_operator_subscription.object().model.status.installedCSV.split(".v")[1]
+            version = _ocp.apicast_operator_subscription.model.status.installedCSV.split(".v")[1]
             version = version.split("-")[0]
             Version(version)
         except (ValueError, IndexError, OpenShiftPythonException, InvalidVersion):

--- a/testsuite/openshift/client.py
+++ b/testsuite/openshift/client.py
@@ -214,52 +214,54 @@ class OpenShiftClient:
         objects = self.do_action("process", [source, opt_args]).out()
         self.create(objects)
 
-    def get_operator(self):
+    @property
+    def threescale_operator(self):
         """
-        Gets the selector for the 3scale operator
+        Gets the 3scale operator
 
-        :return: the operator pod
+        :return: the operator pod APIObject
         """
         def select_operator(apiobject):
             return apiobject.get_label("com.redhat.component-name") == "3scale-operator" \
                 or apiobject.get_label("rht.subcomp") == "3scale_operator"
 
-        return self.select_resource("pods", narrow_function=select_operator)
+        return self.select_resource("pods", narrow_function=select_operator).object()
 
-    def get_apicast_operator(self):
+    @property
+    def apicast_operator(self):
         """
-        Gets the selector for the apicast operator
+        Gets the apicast operator
 
-        :return: the operator pod
+        :return: the operator pod APIObject
         """
         def select_operator(apiobject):
             return apiobject.get_label("com.redhat.component-name") == "apicast-operator" \
                 or apiobject.get_label("rht.subcomp") == "apicast_operator"
 
-        return self.select_resource("pods", narrow_function=select_operator)
+        return self.select_resource("pods", narrow_function=select_operator).object()
 
     @property
     def apicast_operator_subscription(self):
         """
-        Gets the selector for the apicast-operator subscription
+        Gets the apicast-operator subscription
 
-        :return: the subscription
+        :return: the subscription APIObject
         """
 
         def select_operator(subscription):
             return subscription.model.spec.name == "apicast-operator"
 
-        return self.select_resource("subscriptions", narrow_function=select_operator)
+        return self.select_resource("subscriptions", narrow_function=select_operator).object()
 
     @property
     def has_apicast_operator(self):
         """True if apicast operator is found in local namespace or in openshift-operators"""
         try:
-            return self.apicast_operator_subscription.object() is not None
+            return self.apicast_operator_subscription is not None
         except oc.OpenShiftPythonException:
             ocp = OpenShiftClient("openshift-operators", self.server_url, self.token)
             try:
-                return ocp.apicast_operator_subscription.object() is not None
+                return ocp.apicast_operator_subscription is not None
             except oc.OpenShiftPythonException:
                 return False
 

--- a/testsuite/tests/images/test_images_check.py
+++ b/testsuite/tests/images/test_images_check.py
@@ -61,13 +61,13 @@ def test_apicast_image(images, staging_gateway):
 @pytest.fixture(scope="module")
 def apicast_operator(staging_gateway):
     """return: Self-managed Apicast operator"""
-    return staging_gateway.openshift.get_apicast_operator().object()
+    return staging_gateway.openshift.apicast_operator
 
 
 @pytest.fixture(scope="module")
 def threescale_operator(openshift):
     """return: 3scale operator"""
-    return openshift().get_operator().object()
+    return openshift().threescale_operator
 
 
 @pytest.mark.parametrize("operator_type", ["threescale_operator", "apicast_operator"])

--- a/testsuite/tests/operator/conftest.py
+++ b/testsuite/tests/operator/conftest.py
@@ -1,12 +1,13 @@
 """conftest for operator tests"""
 
 import pytest
+from openshift import OpenShiftPythonException
 
 
 @pytest.fixture(scope="session")
 def operator(openshift):
     """Return operator pod object."""
-    pod = openshift().get_operator()
-    if not pod.object_list:
-        pod = openshift(project='openshift-operators').get_operator()
-    return pod.object()
+    try:
+        return openshift().threescale_operator
+    except OpenShiftPythonException:
+        return openshift(project='openshift-operators').threescale_operator


### PR DESCRIPTION
- All methods are now properties
- All methods now return APIObject or None
  - All the methods that previously returned Selector were always called with `.object()`, and only sometimes try-excepted the potential OpenShiftException when it didn't exist. Now, they will never throw exceptions.
- Change the naming of these methods to reflect their current state better.

This is a breaking change