### PR TITLE
Cleanup skipping implemented on pytest level

### DIFF
--- a/testsuite/tests/apicast/parameters/auth/test_rhsso_wrong_realm.py
+++ b/testsuite/tests/apicast/parameters/auth/test_rhsso_wrong_realm.py
@@ -25,8 +25,7 @@ def user_wrong_realm(rhsso_service_info, request, testconfig):
     """User in a wrong realm"""
     realm = rhsso_service_info.rhsso.create_realm(blame(request, "realm2"), accessTokenLifespan=24 * 60 * 60)
 
-    if not testconfig["skip_cleanup"]:
-        request.addfinalizer(realm.delete)
+    request.addfinalizer(realm.delete)
 
     client = realm.create_client(
         name=blame(request, "client2"),

--- a/testsuite/tests/apicast/parameters/conftest.py
+++ b/testsuite/tests/apicast/parameters/conftest.py
@@ -15,11 +15,10 @@ def require_openshift(testconfig):
 
 
 @pytest.fixture(scope="module")
-def staging_gateway(request, gateway_kind, gateway_environment, gateway_options, testconfig):
+def staging_gateway(request, gateway_kind, gateway_environment, gateway_options):
     """Deploy self-managed template based apicast gateway."""
     gw = gateway(kind=gateway_kind, staging=True, name=blame(request, "gw"), **gateway_options)
-    if not testconfig["skip_cleanup"]:
-        request.addfinalizer(gw.destroy)
+    request.addfinalizer(gw.destroy)
     gw.create()
 
     if len(gateway_environment) > 0:

--- a/testsuite/tests/apicast/policy/test_policy_registry.py
+++ b/testsuite/tests/apicast/policy/test_policy_registry.py
@@ -40,7 +40,7 @@ def schema():
 
 
 @pytest.fixture
-def custom_policies(threescale, schema, request, testconfig):
+def custom_policies(threescale, schema):
     """Create custom policies"""
     policies = []
 
@@ -51,12 +51,10 @@ def custom_policies(threescale, schema, request, testconfig):
     policy = threescale.policy_registry.create(params=params2)
     policies.append(policy)
 
-    if not testconfig["skip_cleanup"]:
-        def _cleanup():
-            for policy in policies:
-                threescale.policy_registry.delete(policy["id"])
+    yield
 
-        request.addfinalizer(_cleanup)
+    for policy in policies:
+        threescale.policy_registry.delete(policy["id"])
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/custom_tenant/test_custom_tenant.py
+++ b/testsuite/tests/custom_tenant/test_custom_tenant.py
@@ -40,7 +40,7 @@ def account(custom_account, request, account_password):
 
 
 @pytest.fixture(scope="module")
-def custom_account(threescale, request, testconfig):
+def custom_account(threescale, request):
     """ Local module scoped custom_account to utilize custom tenant
 
     Args:
@@ -48,7 +48,7 @@ def custom_account(threescale, request, testconfig):
     """
     def _custom_account(params, autoclean=True, threescale_client=threescale):
         acc = resilient.accounts_create(threescale_client, params=params)
-        if autoclean and not testconfig["skip_cleanup"]:
+        if autoclean:
             request.addfinalizer(acc.delete)
         return acc
 

--- a/testsuite/tests/images/test_images_check.py
+++ b/testsuite/tests/images/test_images_check.py
@@ -35,11 +35,10 @@ def test_deployment_image(images, openshift, image, image_stream, deployment_con
 
 
 @pytest.fixture(scope="module")
-def staging_gateway(request, testconfig):
+def staging_gateway(request):
     """Deploy self-managed template based apicast gateway."""
     gw = gateway(kind=OperatorApicast, staging=True, name=blame(request, "gw"))
-    if not testconfig["skip_cleanup"]:
-        request.addfinalizer(gw.destroy)
+    request.addfinalizer(gw.destroy)
     gw.create()
     return gw
 

--- a/testsuite/tests/service_mesh/auth/rhsso/test_rhsso_wrong_realm.py
+++ b/testsuite/tests/service_mesh/auth/rhsso/test_rhsso_wrong_realm.py
@@ -14,8 +14,7 @@ def user_wrong_realm(rhsso_service_info, request, testconfig):
     """User in a wrong realm"""
     realm = rhsso_service_info.rhsso.create_realm(blame(request, "realm2"), accessTokenLifespan=24 * 60 * 60)
 
-    if not testconfig["skip_cleanup"]:
-        request.addfinalizer(realm.delete)
+    request.addfinalizer(realm.delete)
 
     client = realm.create_client(
         name=blame(request, "client2"),

--- a/testsuite/tests/toolbox/test_backend.py
+++ b/testsuite/tests/toolbox/test_backend.py
@@ -7,7 +7,6 @@ import string
 import pytest
 from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from testsuite.config import settings
 from testsuite.toolbox import toolbox
 import testsuite.utils
 from testsuite import TESTED_VERSION  # noqa # pylint: disable=unused-import
@@ -44,9 +43,8 @@ def my_backend_metrics(request, my_backend):
         metric = my_backend.metrics.create(params=params)
         metrics.append(metric)
     yield metrics
-    if not settings["skip_cleanup"]:
-        for met in metrics:
-            met.delete()
+    for met in metrics:
+        met.delete()
 
 
 @pytest.fixture(scope="module")
@@ -65,9 +63,8 @@ def my_backend_methods(request, my_backend):
         method = metr.methods.create(params=params)
         methods.append(method)
     yield methods
-    if not settings["skip_cleanup"]:
-        for met in methods:
-            met.delete()
+    for met in methods:
+        met.delete()
 
 
 @pytest.fixture(scope="module")
@@ -85,9 +82,8 @@ def my_backend_mappings(my_backend, my_backend_metrics):
             mapp = my_backend.mapping_rules.create(params=params)
             mapping_rules.append(mapp)
     yield mapping_rules
-    if not settings["skip_cleanup"]:
-        for mapp in mapping_rules:
-            mapp.delete()
+    for mapp in mapping_rules:
+        mapp.delete()
 
 
 # pylint: disable=too-many-arguments

--- a/testsuite/tests/toolbox/test_method.py
+++ b/testsuite/tests/toolbox/test_method.py
@@ -3,8 +3,6 @@
 import re
 import pytest
 
-from testsuite.config import settings
-
 import testsuite
 from testsuite import rawobj
 from testsuite.utils import blame
@@ -23,8 +21,7 @@ def hits(request, service):
         'unit': 'Hit'}
     method = hits.methods.create(params=params)
     yield hits
-    if not settings["skip_cleanup"]:
-        method.delete()
+    method.delete()
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/toolbox/test_metric.py
+++ b/testsuite/tests/toolbox/test_metric.py
@@ -3,8 +3,6 @@
 import re
 import pytest
 
-from testsuite.config import settings
-
 import testsuite
 from testsuite import rawobj
 from testsuite.utils import blame
@@ -24,8 +22,7 @@ def metric_obj(request, service):
         'unit': 'Hit'}
     metric = service.metrics.create(params=params)
     yield service
-    if not settings["skip_cleanup"]:
-        metric.delete()
+    metric.delete()
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/toolbox/test_openapi.py
+++ b/testsuite/tests/toolbox/test_openapi.py
@@ -90,9 +90,8 @@ def import_oas(threescale_dst1, dest_client, request, oas):
         r'^(Created|Updated) service id: (\d+), name: (.+)$', ret['stdout'], re.MULTILINE)[0]
     service = dest_client.services[int(service_id)]
     yield (ret, service_id, service_name, service)
-    if not settings["skip_cleanup"]:
-        service.delete()
-        toolbox.run_cmd(f"rm -f {oas['file_name']}", False)
+    service.delete()
+    toolbox.run_cmd(f"rm -f {oas['file_name']}", False)
 
 
 @pytest.fixture(scope="module")
@@ -114,11 +113,10 @@ def import_oas_backend(threescale_dst1, dest_client, oas, import_oas):
     backend = dest_client.backends[int(output['id'])]
 
     yield (ret, output, backend)
-    if not settings["skip_cleanup"]:
-        for bus in service.backend_usages.list():
-            bus.delete()
-        backend.delete()
-        toolbox.run_cmd(f"rm -f {oas['file_name']}", False)
+    for bus in service.backend_usages.list():
+        bus.delete()
+    backend.delete()
+    toolbox.run_cmd(f"rm -f {oas['file_name']}", False)
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/toolbox/test_policies_imp_exp.py
+++ b/testsuite/tests/toolbox/test_policies_imp_exp.py
@@ -29,8 +29,7 @@ def import_policies(threescale_src1, policy_file, service):
     assert not ret['stderr']
 
     yield ret['stdout']
-    if not settings["skip_cleanup"]:
-        toolbox.run_cmd('rm -f ' + policy_file, False)
+    toolbox.run_cmd('rm -f ' + policy_file, False)
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/toolbox/test_product_backend_exp.py
+++ b/testsuite/tests/toolbox/test_product_backend_exp.py
@@ -39,7 +39,7 @@ def service(my_backends_mapping, custom_service, service_settings, policy_config
 
 
 @pytest.fixture(scope="module")
-def my_metrics(service, testconfig):
+def my_metrics(service):
     """Fixture creates metrics for service."""
     proxy = service.proxy.list()
 
@@ -60,9 +60,8 @@ def my_metrics(service, testconfig):
     proxy.deploy()
 
     yield metric1, metric2
-    if not testconfig["skip_cleanup"]:
-        metric1.delete()
-        metric2.delete()
+    metric1.delete()
+    metric2.delete()
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/toolbox/test_product_copy.py
+++ b/testsuite/tests/toolbox/test_product_copy.py
@@ -45,7 +45,7 @@ def service(my_backends_mapping, custom_service, service_settings, policy_config
 
 
 @pytest.fixture(scope="module")
-def my_metrics(service, testconfig):
+def my_metrics(service):
     """Fixture creates metrics for service."""
     proxy = service.proxy.list()
 
@@ -70,9 +70,8 @@ def my_metrics(service, testconfig):
     proxy.deploy()
 
     yield metric1, metric2
-    if not testconfig["skip_cleanup"]:
-        metric1.delete()
-        metric2.delete()
+    metric1.delete()
+    metric2.delete()
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/toolbox/test_product_update.py
+++ b/testsuite/tests/toolbox/test_product_update.py
@@ -37,18 +37,17 @@ def service_settings(request, product_service):
 
 
 @pytest.fixture(scope="module")
-def service(testconfig, custom_service, my_backends_mapping, service_settings, policy_configs):
+def service(custom_service, my_backends_mapping, service_settings, policy_configs):
     """Service fixture"""
     service = custom_service(service_settings, backends=my_backends_mapping)
     service.proxy.list().policies.append(*policy_configs)
     yield service
-    if not testconfig["skip_cleanup"]:
-        for back_usage in service.backend_usages.list():
-            back_usage.delete()
+    for back_usage in service.backend_usages.list():
+        back_usage.delete()
 
 
 @pytest.fixture(scope="module")
-def my_metrics(service, testconfig):
+def my_metrics(service):
     """Fixture creates metrics for service."""
     proxy = service.proxy.list()
 
@@ -69,9 +68,8 @@ def my_metrics(service, testconfig):
     proxy.deploy()
 
     yield metric1, metric2
-    if not testconfig["skip_cleanup"]:
-        metric1.delete()
-        metric2.delete()
+    metric1.delete()
+    metric2.delete()
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/toolbox/test_remote.py
+++ b/testsuite/tests/toolbox/test_remote.py
@@ -106,10 +106,9 @@ def test_list4():
 def teardown_module(module):
     """Teardown for module - remove all remotes"""
     # pylint: disable=unused-argument
-    if not settings["skip_cleanup"]:
-        ret = toolbox.run_cmd(create_cmd('list'))
-        if ret['stdout'] != EMPTY_LIST:
-            line_reg = re.compile('^([^ ]*)')
-            for remote in ret['stdout'].splitlines():
-                remote_name = line_reg.match(remote).groups()[0]
-                toolbox.run_cmd(create_cmd(f"remove {remote_name}"))
+    ret = toolbox.run_cmd(create_cmd('list'))
+    if ret['stdout'] != EMPTY_LIST:
+        line_reg = re.compile('^([^ ]*)')
+        for remote in ret['stdout'].splitlines():
+            remote_name = line_reg.match(remote).groups()[0]
+            toolbox.run_cmd(create_cmd(f"remove {remote_name}"))

--- a/testsuite/tests/toolbox/test_service_csv.py
+++ b/testsuite/tests/toolbox/test_service_csv.py
@@ -61,8 +61,7 @@ def import_csv(threescale_dst1, copy_string_to_remote):
     assert not ret['stderr']
 
     yield ret['stdout']
-    if not settings["skip_cleanup"]:
-        toolbox.run_cmd('rm -f ' + copy_string_to_remote, False)
+    toolbox.run_cmd('rm -f ' + copy_string_to_remote, False)
 
 
 @pytest.fixture(scope="module")
@@ -73,10 +72,9 @@ def services(import_csv, dest_client):
     for name in services_names:
         services[name] = dest_client.services.read_by(**{'name': name})
     yield services
-    if not settings["skip_cleanup"]:
-        for service in services.values():
-            if service:
-                service.delete()
+    for service in services.values():
+        if service:
+            service.delete()
 
 
 @pytest.fixture(scope="module")
@@ -91,10 +89,9 @@ def metrics(import_csv, services, import_data):
                 service = services[line['service_name']]
         metrics.append(service.metrics.read_by(**{'friendly_name': name}))
     yield metrics
-    if not settings["skip_cleanup"]:
-        for met in metrics:
-            if met:
-                met.delete()
+    for met in metrics:
+        if met:
+            met.delete()
 
 
 @pytest.fixture(scope="module")
@@ -110,10 +107,9 @@ def methods(import_csv, import_data, services):
         hits = service.metrics['hits']
         methods.append(hits.methods.read_by(**{'friendly_name': name}))
     yield methods
-    if not settings["skip_cleanup"]:
-        for meth in methods:
-            if meth:
-                meth.delete()
+    for meth in methods:
+        if meth:
+            meth.delete()
 
 
 @pytest.fixture(scope="module")
@@ -128,11 +124,10 @@ def mapping_rules(import_csv, services):
             maps.append(service.mapping_rules.read_by(**{'pattern': '/anything/' + name}))
         mappings.append(maps)
     yield mappings
-    if not settings["skip_cleanup"]:
-        for mapps in mappings:
-            for mapp in mapps:
-                if mapp:
-                    mapp.delete()
+    for mapps in mappings:
+        for mapp in mapps:
+            if mapp:
+                mapp.delete()
 
 
 def test_services(import_csv, services):

--- a/testsuite/tests/ui/auth/conftest.py
+++ b/testsuite/tests/ui/auth/conftest.py
@@ -22,13 +22,12 @@ def ui_sso_integration(custom_admin_login, navigator, threescale, testconfig, re
         sso_id = sso.create(sso_type, client, client_secret, realm)
         sso = threescale.admin_portal_auth_providers.read(sso_id)
 
-        if not testconfig["skip_cleanup"]:
-            def _delete():
-                custom_admin_login()
-                sso_edit = navigator.navigate(SSOIntegrationEditView, integration=sso)
-                sso_edit.delete()
+        def _delete():
+            custom_admin_login()
+            sso_edit = navigator.navigate(SSOIntegrationEditView, integration=sso)
+            sso_edit.delete()
 
-            request.addfinalizer(_delete)
+        request.addfinalizer(_delete)
         return sso
 
     return _sso_integration
@@ -56,10 +55,9 @@ def auth0_setup(ui_sso_integration, testconfig, navigator, set_callback_urls, au
 
     yield urls
 
-    if not testconfig["skip_cleanup"]:
-        name = auth0_user["email"].split("@")[0]
-        user = resilient.resource_read_by_name(threescale.provider_account_users, name)
-        user.delete()
+    name = auth0_user["email"].split("@")[0]
+    user = resilient.resource_read_by_name(threescale.provider_account_users, name)
+    user.delete()
 
 
 @pytest.fixture

--- a/testsuite/tests/ui/devel/auth/conftest.py
+++ b/testsuite/tests/ui/devel/auth/conftest.py
@@ -9,7 +9,7 @@ from testsuite.ui.views.devel.login import LoginView
 
 # pylint: disable=too-many-arguments
 @pytest.fixture(scope="module")
-def custom_devel_auth0_login(browser, navigator, provider_account, threescale, testconfig):
+def custom_devel_auth0_login(browser, navigator, provider_account, threescale):
     """
     Login to Developer portal with specific account or credentials
     :param browser: Browser instance
@@ -32,16 +32,15 @@ def custom_devel_auth0_login(browser, navigator, provider_account, threescale, t
 
     yield _login
 
-    if not testconfig["skip_cleanup"]:
-        for email in cleanup:
-            name = email.split("@")[0]
-            account = [x for x in threescale.accounts.list() if x.users.list()[0]['username'] == name][0]
-            account.delete()
+    for email in cleanup:
+        name = email.split("@")[0]
+        account = [x for x in threescale.accounts.list() if x.users.list()[0]['username'] == name][0]
+        account.delete()
 
 
 # pylint: disable=too-many-arguments
 @pytest.fixture(scope="module")
-def custom_devel_rhsso_login(browser, navigator, provider_account, threescale, testconfig):
+def custom_devel_rhsso_login(browser, navigator, provider_account, threescale):
     """
     Login to Developer portal with specific account or credentials
     :param browser: Browser instance
@@ -65,7 +64,6 @@ def custom_devel_rhsso_login(browser, navigator, provider_account, threescale, t
 
     yield _login
 
-    if not testconfig["skip_cleanup"]:
-        for username in cleanup:
-            account = [x for x in threescale.accounts.list() if x.users.list()[0]['username'] == username][0]
-            account.delete()
+    for username in cleanup:
+        account = [x for x in threescale.accounts.list() if x.users.list()[0]['username'] == username][0]
+        account.delete()

--- a/testsuite/tests/ui/devel/auth/test_login_auth0.py
+++ b/testsuite/tests/ui/devel/auth/test_login_auth0.py
@@ -7,7 +7,7 @@ from testsuite.ui.views.devel import SignUpView, BaseDevelView
 
 
 @pytest.fixture(scope="module")
-def auth0_integration(request, threescale, testconfig, custom_admin_login, navigator):
+def auth0_integration(threescale, custom_admin_login, navigator):
     """
     Due to the fact that once you create sso integration you can't delete it only edit it,
     this workaround is needed to simplify UI test
@@ -17,15 +17,11 @@ def auth0_integration(request, threescale, testconfig, custom_admin_login, navig
         auth = [threescale.dev_portal_auth_providers.create(
             {"kind": "auth0", "client_id": "tmp", "client_secret": "tmp", "site": "https://anything.invalid"})]
 
-    if not testconfig["skip_cleanup"]:
-        def _delete():
-            custom_admin_login()
-            sso_edit = navigator.navigate(Auth0IntegrationDetailView, integration=auth[0])
-            sso_edit.publish_checkbox.check(False)
+    yield auth[0]
 
-        request.addfinalizer(_delete)
-
-    return auth[0]
+    custom_admin_login()
+    sso_edit = navigator.navigate(Auth0IntegrationDetailView, integration=auth[0])
+    sso_edit.publish_checkbox.check(False)
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/testsuite/tests/ui/devel/auth/test_login_recaptcha.py
+++ b/testsuite/tests/ui/devel/auth/test_login_recaptcha.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.sandbag
 
 
 @pytest.fixture(scope="function")
-def ui_devel_account(request, testconfig, threescale):
+def ui_devel_account(request, threescale):
     """
     Creates a unique username and deletes account associated with it after the test finishes running
     """
@@ -20,9 +20,8 @@ def ui_devel_account(request, testconfig, threescale):
 
     yield user_name
 
-    if not testconfig["skip_cleanup"]:
-        usr = threescale.accounts.read_by_name(user_name)
-        request.addfinalizer(usr.delete)
+    usr = threescale.accounts.read_by_name(user_name)
+    request.addfinalizer(usr.delete)
 
 
 # pylint: disable=unused-argument

--- a/testsuite/tests/ui/devel/auth/test_login_rhsso.py
+++ b/testsuite/tests/ui/devel/auth/test_login_rhsso.py
@@ -8,7 +8,7 @@ from testsuite.ui.views.devel import BaseDevelView
 
 
 @pytest.fixture(scope="module")
-def rhsso_integration(request, threescale, testconfig, custom_admin_login, navigator):
+def rhsso_integration(threescale, custom_admin_login, navigator):
     """
     Due to the fact that once you create sso integration you can't delete it only edit it,
     this workaround is needed to simplify UI test
@@ -18,15 +18,11 @@ def rhsso_integration(request, threescale, testconfig, custom_admin_login, navig
         rhsso = [threescale.dev_portal_auth_providers.create(
             {"kind": "keycloak", "client_id": "tmp", "client_secret": "tmp", "site": "https://anything.invalid"})]
 
-    if not testconfig["skip_cleanup"]:
-        def _delete():
-            custom_admin_login()
-            sso_edit = navigator.navigate(RHSSOIntegrationDetailView, integration=rhsso[0])
-            sso_edit.publish_checkbox.check(False)
+    yield rhsso[0]
 
-        request.addfinalizer(_delete)
-
-    return rhsso[0]
+    custom_admin_login()
+    sso_edit = navigator.navigate(RHSSOIntegrationDetailView, integration=rhsso[0])
+    sso_edit.publish_checkbox.check(False)
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/testsuite/tests/ui/test_service_discovery.py
+++ b/testsuite/tests/ui/test_service_discovery.py
@@ -13,12 +13,13 @@ def service(login, navigator, threescale, testconfig, request):
     view.discover()
 
     service = resilient.resource_read_by_name(threescale.services, "tools-go-httpbin")
-    if not testconfig["skip_cleanup"]:
-        backend_id = service.backend_usages.list()[0]['backend_id']
-        backend = threescale.backends.get(backend_id)
-        request.addfinalizer(backend.delete)
-        request.addfinalizer(service.delete)
-    return service
+
+    yield service
+
+    backend_id = service.backend_usages.list()[0]['backend_id']
+    backend = threescale.backends.get(backend_id)
+    backend.delete()
+    service.delete()
 
 
 @pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-8867")


### PR DESCRIPTION
Generic cleanup skipping without a need to explicitly handle it in
fixtures. On the other hand uses private access == unstable interface
that can stop working one day.
