### PR TITLE
Posibility to define all tools via env

### DIFF
--- a/config/settings.yaml.tpl
+++ b/config/settings.yaml.tpl
@@ -68,12 +68,22 @@ default:
         webdriver: "" #chrome , firefox or edge(edge with remote drivers)
         remote_url: "" #URL and port to remote selenium instance e.g. http://127.0.0.1:4444
     tools:
-      # tools is a fixture to provide testenv services like echo_api, jaeger and services that are needed for testing
-      # each service is identified by a key, for compatibility reasons some keys are predefined as they have been
-      # user in threescale:services:backends of this config. OpenshiftProject implementation inroduced route based
-      # keys and some special key to add extra information. so 'httpbin+https' returns https:// url based on route
-      # to httpbin. There is also logic to define openshift service url e.g. 'httpbin+svc:8888'
-      # returns 'httpbin.{tools-namespace}.svc:8888
+      # tools is a fixture to provide testenv services like echo_api, jaeger
+      # and services that are needed for testing each service is identified by
+      # a key, for compatibility reasons some keys are predefined as they have
+      # been user in threescale:services:backends of this config, furthermore
+      # the tools read from config are searched there as well. OpenshiftProject
+      # implementation inroduced route based keys and some special key to add
+      # extra information. so 'httpbin+https' returns https:// url based on
+      # route to httpbin. There is also logic to define openshift service url
+      # e.g. 'httpbin+svc:8888' returns 'httpbin.{tools-namespace}.svc:8888
+      # This logic makes the computation on its own and such option does not
+      # have to be defined in the config. However can be in this config as
+      # well. In that case, obviously the value has to be defined explicitly.
+      # Such key with '+' and ':' can not be defined as env variable therefore
+      # if `httpbin+svc:8888` is not found also `httpbin_plus_svc_port_8888` is
+      # searched, this latter key can be used also in the config, however it
+      # should not be, this is just for env.
       sources: [ Rhoam, OpenshiftProject, Settings ] # Testenv information sources ordered by priority, query ends at first return of some value
       namespace: tools # openshift namespace/project where the testenv tools are deployed
     private_base_url:

--- a/testsuite/tools.py
+++ b/testsuite/tools.py
@@ -85,7 +85,18 @@ class Settings:
     def __getitem__(self, name):
         if name == "no-ssl-sso":
             return settings["rhsso"]["url"]
-        return settings["threescale"]["service"]["backends"][name]
+        try:
+            return settings["threescale"]["service"]["backends"][name]
+        except KeyError as err:
+            if "+" in name or ":" in name:
+                # env variable name can't contain '+' or ':', though keep the option
+                # to pass the value via env
+                name = name.replace("+", "_plus_").replace(":", "_port_")
+                try:
+                    return settings["threescale"]["service"]["backends"][name]
+                except KeyError:  # pylint: disable=raise-missing-from
+                    raise err
+            raise err
 
 
 class Rhoam(OpenshiftProject):


### PR DESCRIPTION
Some tools can be defined with :port or +extra flag. These chars can't
be part of env variable name. Therefore some "magic" has to happen to
allow these options be passed via env. Simple substitutions /+/_plus_/
and /:/_port_/ are made when searching for value.
