### PR TITLE
fitler out braintree warning in pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -13,6 +13,8 @@ filterwarnings =
     ignore: WARNING the new order is not taken into account:UserWarning
     ignore::urllib3.exceptions.InsecureRequestWarning
     ignore::cryptography.utils.CryptographyDeprecationWarning
+    ignore: Use ProtectionLevel enum instead:DeprecationWarning
+    ignore: Use protection_level parameter instead:DeprecationWarning
 
 log_format=%(asctime)s %(levelname)s:%(name)s:%(message)s
 log_date_format=%H:%M:%S %z


### PR DESCRIPTION
Braintree reports few deprecation warnings that needs to be cleared.
This is not our code, upstream has to fix it.
