### PR TITLE
Fix fixture used for apicast_operator tests

### DIFF
--- a/testsuite/tests/apicast_operator/test_annotations.py
+++ b/testsuite/tests/apicast_operator/test_annotations.py
@@ -38,9 +38,9 @@ ANNOTATIONS_POST_2_12: List[Union[Tuple[str, str], Tuple[str, None]]] = [
 
 @pytest.mark.skipif("APICAST_OPERATOR_VERSION >  Version('0.6.0')")  # since threescale 2.12
 @pytest.mark.parametrize("annotation,expected_value", ANNOTATIONS_PRE_2_12)
-def test_labels_operator_old(annotation, expected_value, operator):
+def test_labels_operator_old(annotation, expected_value, apicast_operator):
     """ Test labels of operator pod. """
-    value = operator.get_annotation(annotation)
+    value = apicast_operator.get_annotation(annotation)
     assert value is not None
     if expected_value:
         assert value == expected_value
@@ -48,9 +48,9 @@ def test_labels_operator_old(annotation, expected_value, operator):
 
 @pytest.mark.skipif("APICAST_OPERATOR_VERSION <= Version('0.6.0')")
 @pytest.mark.parametrize("annotation,expected_value", ANNOTATIONS_POST_2_12)
-def test_labels_operator_new(annotation, expected_value, operator):
+def test_labels_operator_new(annotation, expected_value, apicast_operator):
     """ Test labels of operator pod. """
-    value = operator.get_annotation(annotation)
+    value = apicast_operator.get_annotation(annotation)
     assert value is not None
     if expected_value:
         assert value == expected_value


### PR DESCRIPTION
Fixes: b36d9d6 ("Add information about operators and its namespaces into settings")