### PR TITLE
Define usefixtures properly

### DIFF
--- a/testsuite/tests/ui/policies/test_tls_termination_policy_in_ui.py
+++ b/testsuite/tests/ui/policies/test_tls_termination_policy_in_ui.py
@@ -22,8 +22,7 @@ from testsuite.tests.apicast.policy.tls.conftest import require_openshift, stagi
 pytestmark = [
     pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6390"),
-    pytest.mark.usefixtures("login"),
-    pytest.mark.usefixtures("policy_application")]
+    pytest.mark.usefixtures("login", "policy_application")]
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
When more fixtures should be in use with usefixtures, they should be
defined as one mark.
