### PR TITLE
Upgrade plan for custom_tenant if necessary

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -27,7 +27,7 @@ pytest = "*"
 pytest-cases = "*"
 pytest-asyncio = "*"
 requests = "*"
-3scale-api = ">=0.20.0"
+3scale-api = ">=0.30.0"
 dynaconf = "*"
 # python_keycloak = "*"
 # Waiting for https://github.com/marcospereirampj/python-keycloak/pull/201 and https://github.com/marcospereirampj/python-keycloak/pull/200

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -939,7 +939,11 @@ def custom_tenant(testconfig, master_threescale, request):
         if autoclean and not testconfig["skip_cleanup"]:
             request.addfinalizer(tenant.delete)
 
-        master_threescale.accounts.read_by_name(user_name).users.read_by_name(user_name).activate()
+        tenant.account.users.read_by_name(user_name).activate()
+
+        plan_upgrade = weakget(testconfig)["fixtures"]["custom_tenant"]["plan_upgrade"] % False
+        if plan_upgrade:
+            tenant.plan_upgrade(plan_upgrade)
 
         return tenant
 


### PR DESCRIPTION
Posibility to provide plan for new tenant and upgrade tenant to that
plan. Useful when testing special environments with limited tenant by
default.
