### PR TITLE
Updated api docs page object to OAS3

### DIFF
--- a/testsuite/tests/ui/api_docs/test_api_docs_access_token.py
+++ b/testsuite/tests/ui/api_docs/test_api_docs_access_token.py
@@ -1,7 +1,6 @@
 """Test API Docs access token validation: https://issues.redhat.com/browse/THREESCALE-7084"""
 import pytest
 
-from testsuite import rawobj
 from testsuite.ui.views.admin.settings.api_docs import APIDocsView
 
 
@@ -27,7 +26,6 @@ def test_invalid_token(request, navigator, access_token):
     api_docs = navigator.navigate(APIDocsView)
     token = request.getfixturevalue(access_token)[0]
     code = request.getfixturevalue(access_token)[1]
-    status_code = api_docs.endpoint("Authentication Providers Admin Portal List").send_request(
-        rawobj.ApiDocParams(token)
-    )
-    assert status_code == code
+    endpoint = api_docs.endpoint("GET", "/admin/api/account/authentication_providers.xml")
+    endpoint.execute({"access_token": token})
+    assert endpoint.status_code == code

--- a/testsuite/tests/ui/api_docs/test_autocomplete.py
+++ b/testsuite/tests/ui/api_docs/test_autocomplete.py
@@ -1,7 +1,6 @@
 """Rewrite of spec/ui_specs/autocomplete_spec.rb"""
 import pytest
 
-from testsuite import rawobj
 from testsuite.ui.views.admin.settings.api_docs import APIDocsView
 
 
@@ -18,14 +17,12 @@ def test_autocomplete(navigator, service, testconfig):
     token = testconfig["threescale"]["admin"]["token"]
 
     api_docs_page = navigator.navigate(APIDocsView)
-    endpoint = api_docs_page.endpoint("Service Read")
-    endpoint.fill(rawobj.ApiDocParams(token))
-    endpoint.get_param("service_ids").click()
+    endpoint = api_docs_page.endpoint("GET", "/admin/api/services/{id}.xml")
+    endpoint.set_param("access_token", token)
+    endpoint.set_param("id", service["name"])
 
-    product_id_element = api_docs_page.get_id_input_by_name(service["name"])
-    auto_comp_prod_id = product_id_element.text
-    product_id_element.click()
-    assert auto_comp_prod_id == str(service["id"])
+    id_column = endpoint.get_param("id")
+    assert endpoint.extract_text(id_column) == str(service["id"])
 
-    endpoint.submit_button.click()
-    assert endpoint.status_code() == "200"
+    endpoint.execute()
+    assert endpoint.status_code == "200"

--- a/testsuite/tests/ui/oas/test_active_docs_v3.py
+++ b/testsuite/tests/ui/oas/test_active_docs_v3.py
@@ -68,12 +68,16 @@ def test_active_docs_v3_generate_endpoints(navigator, ui_active_doc, service, ap
         - Assert that try endpoint works as expected
     """
     preview_page = navigator.navigate(ActiveDocsDetailView, product=service, active_doc=ui_active_doc)
-    navigator.browser.selenium.refresh()
     preview_page.wait_displayed()
-    assert preview_page.oas3.active_docs_section.endpoints == ["/pets", "/pets", "/pets/{id}", "/pets/{id}"]
+
+    endpoints = preview_page.oas3.endpoint
+    assert len(endpoints) == 4
+    for endpoint, path in zip(endpoints, ["/pets", "/pets", "/pets/{id}", "/pets/{id}"]):
+        assert endpoint.path.text == path
+
     key = f"{application.entity_name} - {service['name']}"
-    preview_page.oas3.make_request("GET", "/pets", key)
-    assert preview_page.oas3.active_docs_section.get_response_code() == "200"
+    preview_page.oas3.endpoint("GET", "/pets").execute({"user_key": key})
+    assert preview_page.oas3.endpoint("GET", "/pets").status_code == "200"
 
 
 @pytest.mark.usefixtures("active_doc")

--- a/testsuite/tests/ui/oas/test_api_key_autocomplete.py
+++ b/testsuite/tests/ui/oas/test_api_key_autocomplete.py
@@ -81,5 +81,6 @@ def test_api_key_autocomplete(
     custom_devel_login(account)
     view = navigator.open(DocsView, path=api_doc_page)
     key = f"{application.entity_name} - {service['name']}"
-    view.active_docs_section.try_it_out("GET", "/", key)
-    assert view.active_docs_section.get_response_code() == "200"
+    endpoint = view.endpoint("GET", "/")
+    endpoint.execute({"user_key": key})
+    assert endpoint.status_code == "200"

--- a/testsuite/ui/views/admin/product/active_docs.py
+++ b/testsuite/ui/views/admin/product/active_docs.py
@@ -4,8 +4,9 @@ from widgetastic.widget import View, Text
 
 from testsuite.ui.views.admin.product import BaseProductView
 from testsuite.ui.widgets.buttons import ThreescaleDeleteButton, ThreescaleEditButton
-from testsuite.ui.widgets import ActiveDocV2Section, ActiveDocV3Section
+from testsuite.ui.widgets import ActiveDocV2Section
 from testsuite.ui.navigation import step
+from testsuite.ui.widgets.oas3 import Endpoint
 
 
 class ActiveDocsView(BaseProductView):
@@ -64,18 +65,8 @@ class ActiveDocsDetailView(BaseProductView):
     class oas3(View):
         """OAS version 3 section"""
 
-        active_docs_section = ActiveDocV3Section()
         server = Text("//label[@for='servers']/select/option")
-
-        def make_request(self, method, path, key):
-            """
-            Make request on preview page
-            :param path string eg. /post, /get
-            :param method string eg. GET, POST
-            :param key string name of application
-            :return:
-            """
-            self.active_docs_section.try_it_out(method, path, key)
+        endpoint = View.nested(Endpoint)
 
     def prerequisite(self):
         return ActiveDocsView

--- a/testsuite/ui/views/admin/settings/api_docs.py
+++ b/testsuite/ui/views/admin/settings/api_docs.py
@@ -3,66 +3,10 @@ View representations of 3scale API Docs pages
 """
 
 import backoff
-from widgetastic.exceptions import NoSuchElementException
-from widgetastic.widget import Text, ParametrizedView, ParametrizedLocator, View, TextInput
-from widgetastic_patternfly4 import Button
+from widgetastic.widget import Text, View
 
 from testsuite.ui.views.admin.settings import BaseSettingsView
-
-
-class _Endpoint(ParametrizedView):
-    """
-    Parametrized View that represents a section (for example "Service Read") in API Docs
-    """
-
-    PARAMETERS = ("endpoint_name",)
-    ROOT = ParametrizedLocator('//a[text()={endpoint_name|quote}]/ancestor::li[contains(@class, "operation")]')
-    ALL_ENDPOINTS = './/a[@class="toggle"]'
-    name = Text(locator='.//a[@class="toggle"]')
-    access_token = TextInput(name="access_token")
-    submit_button = Button(locator='.//button[@class="submit"]')
-    status_code_field = Text(locator='.//div[@class="block response_code"]/pre')
-
-    def unroll(self):
-        """Unrolls the endpoint section"""
-        if not self.submit_button.is_displayed:
-            self.name.click()
-            self.submit_button.wait_displayed()
-
-    def status_code(self):
-        """Returns request status code"""
-        self.status_code_field.wait_displayed()
-        return self.status_code_field.read()
-
-    def get_param(self, param):
-        """Returns input param field"""
-        return self.browser.element(f'.//input[contains(@data-threescale-name, "{param}")]')
-
-    def fill(self, values: dict):
-        """
-        Widgetastic fill method override. Fills Parameter values for API doc endpoint
-        Args:
-            :param values: dict of param_name:param_value
-        """
-        self.unroll()
-        for param in values:
-            self.get_param(param).send_keys(values.get(param))
-
-    def send_request(self, params: dict):
-        """
-        Wraps basic use case for API docs endpoint. Fills endpoint params, sends request and returns response code
-        Args:
-            :param params: dict of param_name:param_value
-            :return response code
-        """
-        self.fill(params)
-        self.submit_button.click()
-        return self.status_code()
-
-    @classmethod
-    def all(cls, browser):
-        """Override of parent class `all` method"""
-        return [(browser.text(el),) for el in browser.elements(cls.ALL_ENDPOINTS)]
+from testsuite.ui.widgets.oas3 import Endpoint
 
 
 class APIDocsView(BaseSettingsView):
@@ -75,18 +19,7 @@ class APIDocsView(BaseSettingsView):
     service_management_api_category = Text(locator='//*[@data-name="service_management_api"]')
     account_management_api_category = Text(locator='//*[@data-name="account_management_api"]')
     policy_registry_api_category = Text(locator='//*[@data-name="policy_registry_api"]')
-    endpoint = View.nested(_Endpoint)
-
-    def get_id_input_by_name(self, name):
-        """
-        Helper method for autocomplete part of a test that tests "Service Read"
-        (it finds the correct autocorrect text and returns its ID)
-        """
-        auto_complete_part = '//*[@id="content"]/div/div[13]/ul/li'
-        for li_index in range(len(self.browser.elements(auto_complete_part))):
-            if self.browser.element(auto_complete_part + f"[{li_index + 1}]/strong").text == name:
-                return self.browser.element(auto_complete_part + f"[{li_index + 1}]/span")
-        raise NoSuchElementException("No element was found")
+    endpoint = View.nested(Endpoint)
 
     def prerequisite(self):
         return BaseSettingsView

--- a/testsuite/ui/views/devel/__init__.py
+++ b/testsuite/ui/views/devel/__init__.py
@@ -2,7 +2,7 @@
 from widgetastic.widget import View, Text, TextInput, GenericLocatorWidget
 
 from testsuite.ui.navigation import Navigable, step
-from testsuite.ui.widgets import ActiveDocV3Section
+from testsuite.ui.widgets.oas3 import Endpoint
 
 
 class Navbar(View, Navigable):
@@ -143,7 +143,7 @@ class DocsView(BaseDevelView):
     """View for Documentation page of devel portal"""
 
     path_pattern = "/docs"
-    active_docs_section = ActiveDocV3Section()
+    endpoint = View.nested(Endpoint)
 
     def __init__(self, parent, path=None):
         super().__init__(parent)
@@ -156,8 +156,4 @@ class DocsView(BaseDevelView):
 
     @property
     def is_displayed(self):
-        return (
-            BaseDevelView.is_displayed.fget(self)
-            and self.path in self.browser.url
-            and self.active_docs_section.is_displayed
-        )
+        return BaseDevelView.is_displayed.fget(self) and self.path in self.browser.url

--- a/testsuite/ui/widgets/__init__.py
+++ b/testsuite/ui/widgets/__init__.py
@@ -395,15 +395,14 @@ class ActiveDocV2Section(Widget):
         """Returns a list of all endpoints registry items as strings."""
         return [self.browser.text(el) for el in self.browser.elements(self.ITEMS_LOCATOR, parent=self)]
 
-    # pylint: disable=raise-missing-from
     def item_element(self, item):
         """Returns a WebElement for given item name.
         :return WebElement
         """
         try:
             return self.browser.element(self.ITEMS_BUTTON_LOCATOR.format(item), parent=self)
-        except NoSuchElementException:
-            raise NoSuchElementException("Item {!r} not found.".format(item))
+        except NoSuchElementException as exc:
+            raise NoSuchElementException("Item {!r} not found.".format(item)) from exc
 
     @backoff.on_exception(backoff.fibo, NoSuchElementException, max_tries=4, jitter=None)
     def try_it_out(self, method):
@@ -411,55 +410,6 @@ class ActiveDocV2Section(Widget):
         :param method string eg. /post, /get
         """
         self.browser.click(self.item_element(method))
-
-    @backoff.on_exception(backoff.fibo, NoSuchElementException, max_tries=4, jitter=None)
-    def get_response_code(self):
-        """Return response code called by method try_it_out"""
-        return self.browser.text(self.RESPONSE_CODE_LOCATOR, parent=self)
-
-
-# pylint: disable=abstract-method
-# Widget contains fill method which raise not implemented exception if widget is not fillable but pylint detect it as
-# an abstract method
-class ActiveDocV3Section(Widget):
-    """Active Doc V3 preview section"""
-
-    ROOT = ParametrizedLocator('//*[@class="operation-tag-content"]')
-    ENDPOINTS_LIST = "./span/div"
-    ITEMS_LOCATOR = "./span/div/div/button/span[2]/a/span"
-    ITEMS_EXPAND_LOCATOR = './span/div/div/button/span[text()="{}"]/../span[2]/a/span[contains(text(),"{}")]'
-    RESPONSE_CODE_LOCATOR = './/*[text()="Server response"]/../table/tbody/tr/td[1]'
-    TRY_OUT_BUTTON_LOCATOR = './/*[@class="btn try-out__btn"]'
-    SELECT_OPTION_LOCATOR = './/select/option[text()="{}"]'
-    EXECUTE_BUTTON_LOCATOR = './/*[@class="btn execute opblock-control__btn"]'
-
-    @property
-    def endpoints(self):
-        """Returns a list of all endpoints registry items as strings."""
-        return [self.browser.text(el) for el in self.browser.elements(self.ITEMS_LOCATOR, parent=self)]
-
-    # pylint: disable=raise-missing-from
-    def item_element(self, method, path):
-        """Returns a WebElement for given item name.
-        :return WebElement
-        """
-        path = path.replace("/", "\u200b/")
-        try:
-            return self.browser.element(self.ITEMS_EXPAND_LOCATOR.format(method, path), parent=self)
-        except NoSuchElementException:
-            raise NoSuchElementException("Method {} with path {} not found.".format(method, path))
-
-    @backoff.on_exception(backoff.fibo, NoSuchElementException, max_tries=4, jitter=None)
-    def try_it_out(self, method, path, key):
-        """Make test request
-        :param path string eg. /post, /get
-        :param method string eg. GET, POST
-        :param key string name of application
-        """
-        self.browser.click(self.item_element(method, path))
-        self.browser.click(self.browser.element(self.TRY_OUT_BUTTON_LOCATOR))
-        self.browser.selenium.find_element(By.XPATH, self.SELECT_OPTION_LOCATOR.format(key)).click()
-        self.browser.click(self.browser.element(self.EXECUTE_BUTTON_LOCATOR))
 
     @backoff.on_exception(backoff.fibo, NoSuchElementException, max_tries=4, jitter=None)
     def get_response_code(self):

--- a/testsuite/ui/widgets/oas3.py
+++ b/testsuite/ui/widgets/oas3.py
@@ -1,0 +1,117 @@
+"""Widgets used by OAS3"""
+from selenium.webdriver.common.by import By
+from widgetastic.utils import ParametrizedLocator
+from widgetastic.widget import ParametrizedView, Text, Table, Widget, TextInput, GenericLocatorWidget
+
+
+# pylint: disable=abstract-method
+
+
+class OAS3DropDown(Widget):
+    """DropDown element used by OAS3. Usually used for key selection or autocomplete function"""
+
+    EXPAND = ".//select"
+    OPTION = './/select/option[contains(text(),"{}")]'
+
+    def __init__(self, parent=None, locator='.//div[@class="examples-select"]', logger=None):
+        super().__init__(parent, locator=locator, logger=logger)
+        self.locator = locator
+
+    def select_item(self, value):
+        """Selects item by their respective values in the select"""
+        item = self.OPTION.format(value)
+        self.browser.selenium.find_element(By.XPATH, item).click()
+
+    def __locator__(self):
+        return self.locator
+
+    def __repr__(self):
+        return "{}{}".format(type(self).__name__, self.locator)
+
+
+class Endpoint(ParametrizedView):
+    """
+    Parametrized View that represents a section (for example "Service Read") in API Docs
+    """
+
+    PARAMETERS = ("endpoint_method", "endpoint_path")
+    ROOT = ParametrizedLocator(
+        "//span[@data-path={endpoint_path|quote}]/.."
+        "/span[text()={endpoint_method|quote}]"
+        '/ancestor::div[contains(@id, "operations")]'
+    )
+    ALL_ENDPOINTS = './/div[@class="operation-tag-content"]/span'
+
+    method = Text(locator='.//span[@class="opblock-summary-method"]')
+    path = Text(locator='.//span[@class="opblock-summary-path"]')
+    try_out_btn = GenericLocatorWidget(locator='.//button[@class="btn try-out__btn"]')
+    execute_btn = GenericLocatorWidget(locator=".//button[contains(@class, 'btn execute')]")
+    parameters = Table('.//table[@class="parameters"]')
+    response = Table('.//table[@class="responses-table live-responses-table"]')
+
+    @property
+    def expanded(self):
+        """Returns True if endpoint section is expanded"""
+        return "is-open" in self.__element__().get_attribute("class")
+
+    @property
+    def status_code(self):
+        """Returns request status code"""
+        self.response.wait_displayed()
+        return self.response[0].code.text
+
+    def expand_item(self):
+        """Expands endpoint section"""
+        if not self.expanded:
+            self.browser.click(self)
+
+    def execute(self, params: dict[str, str] = None):
+        """
+        Executes request to this endpoint by performing few steps (if required or necessary):
+            - Expands current endpoint section
+            - Clicks Try Out button
+            - Sets the parameters
+            - Click Execute button
+        """
+        self.expand_item()
+        if self.try_out_btn.is_displayed:
+            self.try_out_btn.click()
+        if params:
+            for key in params:
+                self.set_param(key, params[key])
+        self.execute_btn.click()
+
+    def get_param(self, key):
+        """Returns value from endpoint parameter from column defined by `key`"""
+        self.expand_item()
+        return self.parameters.row(name__startswith=key).description
+
+    def set_param(self, key, value):
+        """Sets the `value` for the endpoint parameter defined by `key`"""
+        self.expand_item()
+        column = self.get_param(key)
+
+        select = OAS3DropDown(column)
+        text_input = TextInput(column, locator=".//input")
+        if select.is_displayed:
+            select.select_item(value)
+        elif text_input.is_displayed:
+            text_input.fill(value)
+
+    @staticmethod
+    def extract_text(column):
+        """Finds Text Input inside given column and returns its text"""
+        return TextInput(column, locator=".//input").value
+
+    @classmethod
+    def all(cls, browser):
+        """
+        Override of parent class `all` method.
+        Return list of tuples of all method and path parameters that are necessary to identify ParametrizedView.
+        """
+        result = []
+        for element in browser.elements(cls.ALL_ENDPOINTS):
+            endpoint_method = browser.text(browser.element('.//span[@class="opblock-summary-method"]', parent=element))
+            endpoint_path = browser.text(browser.element('.//span[@class="opblock-summary-path"]', parent=element))
+            result.append((endpoint_method, endpoint_path))
+        return result


### PR DESCRIPTION
3scale API Docs are now using OAS3. In addition, all OAS3 page objects now use the same widgets for endpoint representation.
Why we need this PR:

1. OAS3 was used for 3scale API docs (old 3scale design was completely removed)
2. Our OAS3 object used plane selenium (please see deleted code in `class ActiveDocV3Section(Widget)`)
3. Our new `Endpoint` is ParametrizedView, which is an ideal tool from Widgetastic to identify multiple same objects (views) on the same page. By doing this the usage is simple and straightforward:  `view.oas3.endpoint("GET", "/pets").execute({"user_key": key})`
4. Point 3 brought many benefits of Widgetastic to our OAS3 pages. The one that stands out, is that we no longer need so many backoffs for this View.
5. New`Ednpoint`View is the general solution. It brings a one-size-fits-all solution to all the current and future OAS3 UI tests  