### PR TITLE
Do not use weakget to access deployment_type

### DIFF
--- a/testsuite/tests/apicast/test_uri_too_large.py
+++ b/testsuite/tests/apicast/test_uri_too_large.py
@@ -2,8 +2,6 @@
 import pytest
 from packaging.version import Version  # noqa # pylint: disable=unused-import
 
-from weakget import weakget
-
 from testsuite import rawobj, TESTED_VERSION  # noqa # pylint: disable=unused-import
 
 WARN_MESSAGES = [
@@ -24,7 +22,7 @@ pytestmark = [
 @pytest.fixture
 def status_code(testconfig):
     """Expected status code based on testing environment"""
-    if weakget(testconfig)["threescale"]["deployment_type"] == "rhoam":
+    if testconfig["threescale"]["deployment_type"] == "rhoam":
         return 503
     return 414
 


### PR DESCRIPTION
deployment_type is always set in dynaconf_loader
weakget cause "TypeError: 'NoneType' object is not callable"

Fixes: 42b3a25 ("rhoam returns different status on large uri")