### PR TITLE
Update openshift template version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,8 @@ testsuite/resources/apicast.yml: FORCE
 	$(RUNSCRIPT)env-version-check
 	curl -f https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/$(VERSION).GA/apicast-gateway/apicast.yml > $@ || \
 	curl -f https://raw.githubusercontent.com/3scale/3scale-amp-openshift-templates/master/apicast-gateway/apicast.yml > $@
-	sed -i "s/imagePullPolicy:.*/imagePullPolicy: Always/g" $@
+	sed -i -e "s/imagePullPolicy:.*/imagePullPolicy: Always/g" \
+	       -e "/^apiVersion:/s^:.*^: template.openshift.io/v1^" $@
 
 release: ## Create branch of new VERSION (optionally tag VERSION)
 release: tag_release ?= no

--- a/testsuite/resources/apicast.yml
+++ b/testsuite/resources/apicast.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: 3scale-gateway


### PR DESCRIPTION
Newer openshift require different versioning of template. Updating the
version thus and also updating make target to do the change when
refreshing the template.
