### PR TITLE
Change apicast tests to be compatible with persistence plugin

### DIFF
--- a/testsuite/tests/apicast/parameters/filter_by_url/test_oidc_timeout_err_filter_by_url.py
+++ b/testsuite/tests/apicast/parameters/filter_by_url/test_oidc_timeout_err_filter_by_url.py
@@ -52,10 +52,11 @@ def setup(lifecycle_hooks):
 
 
 @pytest.fixture(scope="module")
-def production_gateway(request):
+def production_gateway(request, testconfig):
     """Deploy template APIcast gateway."""
     gw = gateway(kind=TemplateApicast, staging=False, name=blame(request, "production"))
-    request.addfinalizer(gw.destroy)
+    if not testconfig["skip_cleanup"]:
+        request.addfinalizer(gw.destroy)
     gw.create()
 
     gw.environ["APICAST_SERVICES_FILTER_BY_URL"] = ".*.doesnt.exist"

--- a/testsuite/tests/apicast/parameters/test_apicast_access_log_file.py
+++ b/testsuite/tests/apicast/parameters/test_apicast_access_log_file.py
@@ -17,7 +17,6 @@ pytestmark = [
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6193"),
 ]
 
-
 ACCESS_LOG_FILE = "access.log"
 
 
@@ -87,10 +86,12 @@ def assert_apicast_host_match(apicast_url, content, hits):
 
 def test_access_log_lines_match_requests_hits(make_requests, read_log):
     """Logs appended to access log file match number of requests made against gateway."""
+    _, lines_before = read_log(ACCESS_LOG_FILE)
+
     url = make_requests(3)
 
     content, lines = read_log(ACCESS_LOG_FILE)
 
-    assert lines == 3
+    assert lines == lines_before + 3
 
-    assert_apicast_host_match(apicast_host(url), content, 3)
+    assert_apicast_host_match(apicast_host(url), content, lines_before + 3)

--- a/testsuite/tests/apicast/parameters/test_many_oc_apicast_services.py
+++ b/testsuite/tests/apicast/parameters/test_many_oc_apicast_services.py
@@ -33,15 +33,18 @@ def service_names(request):
 
 
 @pytest.fixture(scope="module")
-def create_services(openshift, request, delete_services, service_names):
+def create_services(openshift, request, delete_services, service_names, testconfig):
     """
     Creates services defined by the values from service_names.
     """
     openshift = openshift()
-    request.addfinalizer(delete_services)
+    if not testconfig["skip_cleanup"]:
+        request.addfinalizer(delete_services)
 
     for name in service_names:
         openshift.create_service(name, ServiceTypes.CLUSTER_IP, 8080, 8080)
+
+    return service_names
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/apicast/parameters/test_modular_apicast.py
+++ b/testsuite/tests/apicast/parameters/test_modular_apicast.py
@@ -96,6 +96,7 @@ def set_gateway_image(openshift, staging_gateway, request):
     openshift_client.start_build(build_name_copy)
 
     staging_gateway.set_image(f"{openshift_client.image_stream_repository(image_stream_name)}:latest")
+    return staging_gateway
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
`testsuite/tests/apicast/parameters` tests are now compatible with persistence plugin and can be used during upgrade testing