### PR TITLE
Use dev version for skips of new features

### DIFF
--- a/testsuite/tests/ui/devel/test_devel_sections.py
+++ b/testsuite/tests/ui/devel/test_devel_sections.py
@@ -80,7 +80,7 @@ def dev_portal_group(navigator, request, account, dev_portal_section, custom_adm
 
 @pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-9020")
 @pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-836")
-@pytest.mark.skipif("TESTED_VERSION < Version('2.14')")
+@pytest.mark.skipif("TESTED_VERSION < Version('2.14-dev')")
 @pytest.mark.usefixtures("dev_portal_group")
 def test_dev_portal_sections(account, custom_devel_login, browser, testconfig, dev_portal_page):
     """


### PR DESCRIPTION
The testsuite can identify product version as a dev version (e.g.
2.14-dev). Therefore it is necessary to implement version skip again
dev version to ensure it is executed during test cycle.
