### PR TITLE
Shorten user identification in blame

### DIFF
--- a/testsuite/utils.py
+++ b/testsuite/utils.py
@@ -62,7 +62,7 @@ def blame(request: "FixtureRequest", name: str, tail: int = 5) -> str:
     if "." in context:
         context = context.split(".")[0]
 
-    return randomize(f"{name[:8]}-{_whoami()[:8]}-{context[:9]}", tail=tail)
+    return randomize(f"{name[:8]}-{_whoami()[:6]}-{context[:9]}", tail=tail)
 
 
 def blame_desc(request: "FixtureRequest", text: str = None):


### PR DESCRIPTION
Extending tail by 2 violated fqdn fragment allowed length, therefore shortening user identification. In theory 4 chars would be enough so still some place to safe few positions.