### PR TITLE
Ignore pkg_resources deprecation warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -15,6 +15,7 @@ filterwarnings =
     ignore::cryptography.utils.CryptographyDeprecationWarning
     ignore: Use ProtectionLevel enum instead:DeprecationWarning
     ignore: Use protection_level parameter instead:DeprecationWarning
+    ignore: pkg_resources is deprecated as an API:DeprecationWarning
 
 log_format=%(asctime)s %(levelname)s:%(name)s:%(message)s
 log_date_format=%H:%M:%S %z


### PR DESCRIPTION
This is not used anywhere in the testsuite, but in couple of
dependencies. Not related to this project.
