### PR TITLE
New base class for 3scale custom buttons

### DIFF
--- a/testsuite/ui/views/master/audience/tenant.py
+++ b/testsuite/ui/views/master/audience/tenant.py
@@ -1,11 +1,11 @@
 """View representations of Tenants pages"""
 from widgetastic.widget import TextInput, Text
-from widgetastic_patternfly4 import Button
 
 from testsuite.ui.navigation import step
 from testsuite.ui.views.master.audience import BaseMasterAudienceView
 from testsuite.ui.widgets import AudienceTable
 from testsuite.ui.widgets.buttons import (
+    Button,
     ThreescaleDeleteButton,
     ThreescaleEditButton,
     ThreescaleSubmitButton,
@@ -68,8 +68,8 @@ class TenantDetailView(BaseMasterAudienceView):
     applications_button = Text("//*[contains(@title,'applications')]")
     public_domain = Text(".//th[contains(text(),'Public domain')]/parent::*/td/a")
     admin_domain = Text(".//th[contains(text(),'Admin domain')]/parent::*/td/a")
-    resume_b = Button("Resume", classes=[Button.LINK])
-    suspend_b = Button("Suspend", classes=[Button.LINK])
+    resume_b = Button("Resume", classes=["button-to", "resume"])
+    suspend_b = Button("Suspend", classes=["button-to", "suspend"])
     impersonate_b = Text(".//a[contains(@href,'impersonation')]")
 
     def __init__(self, parent, account):

--- a/testsuite/ui/widgets/buttons.py
+++ b/testsuite/ui/widgets/buttons.py
@@ -4,6 +4,7 @@
 # pylint: disable=abstract-method
 
 import widgetastic_patternfly4
+from widgetastic.xpath import quote
 
 
 class Button(widgetastic_patternfly4.Button):
@@ -14,74 +15,57 @@ class Button(widgetastic_patternfly4.Button):
         return locator.replace("and contains(@class, 'pf-c-button')", "", 1)
 
 
-class ThreescaleCreateButton(Button):
+class ThreescaleButton(widgetastic_patternfly4.Button):
+    """A button with custom xpath locator definition
+
+    Some elements in 3scale can be identified by either class **OR** text
+    label. Widgetastic support just identification by class and text label,
+    therefore a class with custom locator is needed.
+    """
+
+    def __init__(self, parent, text, classes, **kwargs):
+        base = "(self::a or self::button or (self::input and (@type='button' or @type='submit')))"
+        classes = " and ".join(f"contains(@class, {quote(i)})" for i in classes)
+        conditions = f"(({classes}) or contains(text(), {quote(text)}))"
+        super().__init__(parent, locator=f".//*[{base} and {conditions}]", **kwargs)
+
+
+class ThreescaleCreateButton(ThreescaleButton):
     """Specific Create button of 3scale pages"""
 
-    def __init__(
-        self,
-        parent=None,
-        locator=".//*[(self::a or self::button or (self::input and "
-        "(@type='button' or @type='submit'))) and "
-        "(contains(@class, 'create') or contains(text(), 'Create'))]",
-        logger=None,
-    ):
-        super().__init__(parent=parent, locator=locator, logger=logger)
+    def __init__(self, parent=None, **kwargs):
+        super().__init__(parent, "Create", classes=["create"], **kwargs)
 
 
-class ThreescaleDeleteButton(Button):
+class ThreescaleDeleteButton(ThreescaleButton):
     """Specific Delete button of 3scale pages"""
 
-    def __init__(
-        self,
-        parent=None,
-        locator=".//*[(self::a or self::button or (self::input and "
-        "(@type='button' or @type='submit'))) and "
-        "(contains(@class, 'delete') or contains(text(), 'Delete'))]",
-        logger=None,
-    ):
-        super().__init__(parent=parent, locator=locator, logger=logger)
-
-    def click(self, handle_alert=True):
-        """Perform click action with handling alert"""
-        super().click(handle_alert)
+    def __init__(self, parent=None, **kwargs):
+        super().__init__(parent, "Delete", classes=["delete"], **kwargs)
 
 
-class ThreescaleUpdateButton(Button):
+class ThreescaleUpdateButton(ThreescaleButton):
     """Specific Update button of 3scale pages"""
 
-    def __init__(
-        self,
-        parent=None,
-        locator=".//*[(self::a or self::button or (self::input and "
-        "(@type='button' or @type='submit'))) and "
-        "(contains(@class, 'update') or contains(text(), 'Update'))]",
-        logger=None,
-    ):
-        super().__init__(parent=parent, locator=locator, logger=logger)
+    def __init__(self, parent=None, **kwargs):
+        super().__init__(parent, "Update", classes=["update"], **kwargs)
 
 
-class ThreescaleEditButton(Button):
+class ThreescaleEditButton(ThreescaleButton):
     """Specific Edit button of 3scale pages"""
 
-    def __init__(
-        self,
-        parent=None,
-        locator=".//*[(self::a or self::button or (self::input and "
-        "(@type='button' or @type='submit'))) and "
-        "(contains(@class, 'edit') or contains(text(), 'Edit'))]",
-        logger=None,
-    ):
-        super().__init__(parent=parent, locator=locator, logger=logger)
+    def __init__(self, parent=None, **kwargs):
+        super().__init__(parent, "Edit", classes=["edit"], **kwargs)
 
 
-class ThreescaleSubmitButton(Button):
+class ThreescaleSubmitButton(widgetastic_patternfly4.Button):
     """Specific Submit button of 3scale pages"""
 
     def __init__(self, parent=None, locator=".//*[(self::input or self::button) and @type='submit']", logger=None):
         super().__init__(parent, locator=locator, logger=logger)
 
 
-class ThreescaleSearchButton(Button):
+class ThreescaleSearchButton(widgetastic_patternfly4.Button):
     """Specific Search button of 3scale pages"""
 
     def __init__(self, parent=None, locator="//button[contains(text(), 'Search')]", logger=None):

--- a/testsuite/ui/widgets/buttons.py
+++ b/testsuite/ui/widgets/buttons.py
@@ -1,9 +1,19 @@
 """3scale specific buttons"""
 
-from widgetastic_patternfly4 import Button
-
-
+# Following ignore is needed otherwise: Method 'fill' is abstract in class 'Widget' but is not overridden ...
 # pylint: disable=abstract-method
+
+import widgetastic_patternfly4
+
+
+class Button(widgetastic_patternfly4.Button):
+    """Some buttons in 3scale have 'pf-c-button' class missing"""
+
+    def _generate_locator(self, *text, **kwargs):
+        locator = super()._generate_locator(*text, **kwargs)
+        return locator.replace("and contains(@class, 'pf-c-button')", "", 1)
+
+
 class ThreescaleCreateButton(Button):
     """Specific Create button of 3scale pages"""
 


### PR DESCRIPTION
Some 3scale buttons have patternfly class missing thefore customization
is needed. widgetastic has this class "hardcoded" in "_private" method
so customization of returned value is needed.

As a result this modified Button can be used in same way as original
widget, just on elements that do not contain relevant class.