### PR TITLE
Mark operator tests as no-persistence

### DIFF
--- a/testsuite/tests/apicast_operator/test_annotations.py
+++ b/testsuite/tests/apicast_operator/test_annotations.py
@@ -13,6 +13,7 @@ pytestmark = [
     pytest.mark.sandbag,  # requires apicast operator, doesn't have to be available
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-8314"),
     pytest.mark.required_capabilities(Capability.OCP4),
+    pytest.mark.nopersistence,
 ]
 
 ANNOTATIONS_PRE_2_12: List[Union[Tuple[str, str], Tuple[str, None]]] = [

--- a/testsuite/tests/apicast_operator/test_labels.py
+++ b/testsuite/tests/apicast_operator/test_labels.py
@@ -13,6 +13,7 @@ pytestmark = [
     pytest.mark.sandbag,  # requires apicast operator, doesn't have to be available
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-7751"),
     pytest.mark.required_capabilities(Capability.OCP4),
+    pytest.mark.nopersistence,
 ]
 
 LABELS_PRE_2_12: List[Union[Tuple[str, str], Tuple[str, None]]] = [

--- a/testsuite/tests/operator/test_annotations.py
+++ b/testsuite/tests/operator/test_annotations.py
@@ -13,6 +13,7 @@ pytestmark = [
     pytest.mark.sandbag,  # requires operator in same namespace
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-8314"),
     pytest.mark.required_capabilities(Capability.OCP4),
+    pytest.mark.nopersistence,
 ]
 
 ANNOTATIONS_PRE_2_12: List[Union[Tuple[str, str], Tuple[str, None]]] = [

--- a/testsuite/tests/operator/test_labels.py
+++ b/testsuite/tests/operator/test_labels.py
@@ -13,6 +13,7 @@ pytestmark = [
     pytest.mark.sandbag,  # requires operator in same namespace
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-7750"),
     pytest.mark.required_capabilities(Capability.OCP4),
+    pytest.mark.nopersistence,
 ]
 
 LABELS_PRE_2_12: List[Union[Tuple[str, str], Tuple[str, None]]] = [

--- a/testsuite/tests/operator/test_operator_resources.py
+++ b/testsuite/tests/operator/test_operator_resources.py
@@ -13,6 +13,7 @@ pytestmark = [
     pytest.mark.sandbag,  # requires operator in same namespace
     pytest.mark.skipif("TESTED_VERSION < Version('2.10')"),
     pytest.mark.required_capabilities(Capability.OCP4),
+    pytest.mark.nopersistence,
 ]
 
 


### PR DESCRIPTION
Operator tests are marked as no-persistence because during the upgrade process the old operator is uninstalled and a new one is installed