### PR TITLE
Fix in settings template

### DIFF
--- a/config/settings.yaml.tpl
+++ b/config/settings.yaml.tpl
@@ -200,4 +200,4 @@ development:
         amd64:
         ppc64le:
         s390x:
-    threescale_operator: # Multi-arch manifest digest
+    operator: # Multi-arch manifest digest


### PR DESCRIPTION
Image check tests are written in a way that key in settings.yaml must be the same as the name of fixture for given component. In this case there should be only `operator` instead of `threescale_operator`