### PR TITLE
Mark email tests as nopersistence

### DIFF
--- a/testsuite/tests/system/messages/test_account_message.py
+++ b/testsuite/tests/system/messages/test_account_message.py
@@ -5,6 +5,10 @@ When sending message to a developer account, the email is send
 
 import pytest
 
+# fixture fires a one-time event that triggers an email to be sent,
+# this event (sending message to account) is not affected by an upgrade
+pytestmark = [pytest.mark.nopersistence]
+
 
 @pytest.fixture(scope="module")
 def message_body(threescale, account):

--- a/testsuite/tests/system/messages/test_email_accounts.py
+++ b/testsuite/tests/system/messages/test_email_accounts.py
@@ -14,6 +14,9 @@ import backoff
 from testsuite import rawobj
 from testsuite.utils import blame
 
+# the creation of an account triggers a one-time email to be sent; this is not affected by an upgrade
+pytestmark = [pytest.mark.nopersistence]
+
 
 @pytest.fixture(scope="module")
 def application(service, custom_application, custom_app_plan, lifecycle_hooks, request):


### PR DESCRIPTION
Does not make sense to run mail tests with persistence plugin.