### PR TITLE
Compatibility with dynaconf 3.2.0

### DIFF
--- a/testsuite/dynaconf_loader.py
+++ b/testsuite/dynaconf_loader.py
@@ -29,7 +29,6 @@ from weakget import weakget
 from openshift import OpenShiftPythonException
 from testsuite.openshift.client import OpenShiftClient
 
-identifier = "threescale"  # pylint: disable=invalid-name
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
@@ -315,7 +314,7 @@ def load(obj, env=None, silent=None, key=None):
         project_data = {"openshift": {"projects": {"threescale": {"name": project}}}}
 
         settings.update(project_data)
-        obj.update(data, loader_identifier=identifier)
+        obj.update(data)
         obj.update(settings)
         log.info("dynamic dynaconf loader successfully got data from openshift")
     except Exception as err:


### PR DESCRIPTION
Type of loader_identifier has changed, not a string anymore. Removed, we
didn't have use for it.
