### PR TITLE
Improve value of NO_PROXY in http_proxy/large_data tests

### DIFF
--- a/testsuite/tests/apicast/parameters/http_proxy/large_data/conftest.py
+++ b/testsuite/tests/apicast/parameters/http_proxy/large_data/conftest.py
@@ -24,12 +24,14 @@ def gateway_environment(gateway_environment, testconfig, tools):
     """
     rhsso_url = urlparse(tools["no-ssl-sso"]).hostname
     proxy_endpoint = testconfig["proxy"]
+    superdomain = testconfig["threescale"]["superdomain"]
 
     gateway_environment.update(
         {
             "HTTP_PROXY": proxy_endpoint["http"],
             "HTTPS_PROXY": proxy_endpoint["https"],
-            "NO_PROXY": f"backend-listener,system-master,system-provider,{rhsso_url}",
+            "NO_PROXY": "backend-listener,system-master,system-provider,"
+            f"backend-3scale.{superdomain},3scale-admin.{superdomain},{rhsso_url}",
             "APICAST_CONFIGURATION_LOADER": "boot",
             "APICAST_CONFIGURATION_CACHE": 1000,
         }


### PR DESCRIPTION
Current value was insufficient, explicit fqdn hostname of backend-3scale and
3scale-admin was added to avoid usage of proxy when connecting these.
