### PR TITLE
Don't gather app logs on SaaS

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -74,6 +74,8 @@ saas:
     testsuite/tests/system/test_proxy_endpoints_set_spec.py: quiet
   threescale:
     deployment_type: saas
+  reporting:
+    print_app_logs: false
 
 rhoam:
   warn_and_skip:


### PR DESCRIPTION
There is no access to pods, logs are unavailable. This will clean report from alerts.