### PR TITLE
Mark test for system internal calls as flaky

### DIFF
--- a/testsuite/tests/prometheus/system/test_internal_calls.py
+++ b/testsuite/tests/prometheus/system/test_internal_calls.py
@@ -12,6 +12,7 @@ from testsuite.prometheus import get_metrics_keys
 
 pytestmark = [
     pytest.mark.disruptive,
+    pytest.mark.flaky,
     pytest.mark.skipif("TESTED_VERSION < Version('2.10')"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6446"),
 ]


### PR DESCRIPTION
There might be some internal 3scale communication inflating statistics for system calls. there for marking this test as flaky.