### PR TITLE
Specific adjustements for saas environment

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -72,11 +72,21 @@ saas:
     testsuite/tests/apicast/test_uri_too_large.py: quiet
     testsuite/tests/system/oidc: quiet
     testsuite/tests/system/test_proxy_endpoints_set_spec.py: quiet
+    testsuite/tests/ui/auth/test_provider.py: quiet
     testsuite/tests/ui/billing/braintree: quiet
+    testsuite/tests/ui/billing/stripe/test_verification.py: quiet
+    testsuite/tests/ui/devel/auth/test_login_rhsso.py: quiet
+    testsuite/tests/ui/mail_and_messages: quiet
+    testsuite/tests/ui/master/test_master_dashboard.py::test_dashboard_is_loaded_correctly: quiet
+    testsuite/tests/ui/master/test_tenant.py::test_create_tenant: quiet
   threescale:
     deployment_type: saas
   reporting:
     print_app_logs: false
+  braintree:
+    public_key: NOTSET
+    merchant_id: NOTSET
+    private_key: NOTSET
 
 rhoam:
   warn_and_skip:

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,6 +16,7 @@ filterwarnings =
     ignore: Use ProtectionLevel enum instead:DeprecationWarning
     ignore: Use protection_level parameter instead:DeprecationWarning
     ignore: pkg_resources is deprecated as an API:DeprecationWarning
+    ignore: Self-contained HTML report includes link to external resource:UserWarning
 
 log_format=%(asctime)s %(levelname)s:%(name)s:%(message)s
 log_date_format=%H:%M:%S %z

--- a/testsuite/tests/ui/apiap/test_dashboard.py
+++ b/testsuite/tests/ui/apiap/test_dashboard.py
@@ -69,5 +69,7 @@ def test_3scale_version_in_ui(navigator):
     assert dashboard.threescale_version.is_displayed
     if settings["threescale"]["deployment_type"] == "rhoam":
         assert dashboard.threescale_version.text == "Version RHOAM -"
+    elif settings["threescale"]["deployment_type"] == "saas":
+        assert dashboard.threescale_version.text == "Version 2.x -"
     else:
         assert dashboard.threescale_version.text == f"Version {TESTED_VERSION.release[0]}.{TESTED_VERSION.release[1]} -"

--- a/testsuite/tests/ui/billing/stripe/conftest.py
+++ b/testsuite/tests/ui/billing/stripe/conftest.py
@@ -5,6 +5,7 @@ from testsuite.billing import Stripe
 from testsuite.ui.objects import CreditCard
 from testsuite.ui.views.admin.audience.billing import BillingSettingsView
 from testsuite.ui.views.devel.settings.stripe import StripeCCView
+from testsuite.utils import warn_and_skip
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -16,10 +17,15 @@ def gateway_setup(custom_admin_login, navigator, testconfig):
     billing.stripe(testconfig["stripe"]["secret_key"], testconfig["stripe"]["publishable_key"], "empty-webhook")
 
 
+# warn_and_skip ends the test, pylint can't recognize it obviously
+# pylint: disable=inconsistent-return-statements
 @pytest.fixture(scope="session")
 def stripe(testconfig):
     """Stripe API"""
-    return Stripe(testconfig["stripe"]["api_key"])
+    try:
+        return Stripe(testconfig["stripe"]["api_key"])
+    except KeyError:
+        warn_and_skip("Stripe api_key not in config", "fail")
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/ui/master/conftest.py
+++ b/testsuite/tests/ui/master/conftest.py
@@ -1,0 +1,12 @@
+"""This is conftest. For master scoped tests."""
+
+import pytest
+
+from testsuite.utils import warn_and_skip
+
+
+@pytest.fixture(scope="module", autouse=True)
+def skip_saas(testconfig):
+    """Custom tenant seem to be handled bit differently on SaaS"""
+    if testconfig["threescale"]["deployment_type"] == "saas":
+        warn_and_skip(skip_saas.__doc__)

--- a/testsuite/tests/ui/oas/conftest.py
+++ b/testsuite/tests/ui/oas/conftest.py
@@ -27,9 +27,13 @@ def ui_active_doc(custom_admin_login, request, navigator, service, oas3_spec):
 @pytest.fixture(scope="module")
 def prod_client(prod_client):
     """
-    Production client so tests can send request to service production endpoint
+    Production client to promote configs. The client isn't used in tests.
     """
-    client = prod_client()
+    # redeploy=False enables relevant tests to run also on environment without
+    # access to openshift
+    client = prod_client(redeploy=False)
+    # this might be bit pointless without redeploy, however it gives few seconds
+    # to update the env. It doesn't harm.
     response = client.get("/get")
     assert response.status_code == 200
     return client


### PR DESCRIPTION
Series of changes to adjust set of UI tests to be executed on SaaS

- SaaS has displays version differently
- Few adjustements in env: saas
- warn_and_skip for stripe
- prod_client without redeploy in oas tests
- Another warning to ignore
