### PR TITLE
Mark test as nopersistence

### DIFF
--- a/testsuite/tests/apicast/parameters/filter_by_url/test_oidc_timeout_err_filter_by_url.py
+++ b/testsuite/tests/apicast/parameters/filter_by_url/test_oidc_timeout_err_filter_by_url.py
@@ -25,6 +25,7 @@ pytestmark = [
     pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT),
     pytest.mark.skipif("TESTED_VERSION < Version('2.11')"),
     pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-6139"),
+    pytest.mark.nopersistence,
 ]
 
 


### PR DESCRIPTION
Leaving service created by this test cause failures in tests that use apicast kind=OperatorApicast.