### PR TITLE
Enable headless mode for UI tests and set is as default

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -50,6 +50,7 @@ default:
           hostPort: "@format jaeger-query.{this.FIXTURES.tools.namespace}.svc:5778"
     ui:
       browser:
+        headless: true
         source: local
         webdriver: chrome
         remote_url: http://127.0.0.1:4444

--- a/config/settings.yaml.tpl
+++ b/config/settings.yaml.tpl
@@ -64,6 +64,7 @@ default:
           hostPort: "" # route to the jaeger-query (may be internal)
     ui:
       browser:
+        headless: #true/false  (runs UI tests in headless mode - faster than standard mode)
         source: "" #local ,remote or binary
         webdriver: "" #chrome , firefox or edge(edge with remote drivers)
         remote_url: "" #URL and port to remote selenium instance e.g. http://127.0.0.1:4444

--- a/doc/UI_TESTS.md
+++ b/doc/UI_TESTS.md
@@ -20,8 +20,11 @@ latest know webdrivers and store those webdrivers in cache/tmp folders
     To run container use e.g. `podman run -d -p 4444:4444 -p 5900:5900 -v /dev/shm:/dev/shm 
     selenium/standalone-chrome:4.0.0-beta-1-20210215` 
 
-Currently supported browsers options are `firefox`, `chrome` and `edge`
-(edge only for remote webdriver or using binary path)
+`webdriver:`:
+Choose browser type -currently supported browsers options are `firefox`, `chrome`
+
+`headless:`: Run UI tests in headless mode, options are `True/False` (About 30% faster option than classic run) - default is `True`. Use False setting for debugging or run observation
+
 
 There can be also specified 3scale admin url which is used for browser 
 navigation(by default is automatically fetched from dynaconf)

--- a/testsuite/tests/ui/conftest.py
+++ b/testsuite/tests/ui/conftest.py
@@ -45,6 +45,7 @@ def webdriver():
         source=settings["fixtures"]["ui"]["browser"]["source"],
         driver=settings["fixtures"]["ui"]["browser"]["webdriver"],
         ssl_verify=settings["ssl_verify"],
+        headless=settings["fixtures"]["ui"]["browser"]["headless"],
         remote_url=settings["fixtures"]["ui"]["browser"]["remote_url"],
         binary_path=settings["fixtures"]["ui"]["browser"]["binary_path"],
     )

--- a/testsuite/ui/webdriver.py
+++ b/testsuite/ui/webdriver.py
@@ -17,13 +17,13 @@ LOGGER = logging.getLogger(__name__)
 class _Chrome:
     """Factory class for Chrome browser"""
 
-    def __init__(self, source, accept_insecure_certs, remote_url=None, binary_path=None):
+    # pylint: disable=too-many-arguments
+    def __init__(self, source, accept_insecure_certs, headless, remote_url=None, binary_path=None):
         self.source = source
         self.remote_url = remote_url
         self.binary_path = binary_path
         self.webdriver = None
         self.options = ChromeOptions()
-        self.options.set_capability("acceptInsecureCerts", accept_insecure_certs)
         # Allow mixed content in browser HTTP + HTTPS
         self.options.add_experimental_option(
             "prefs",
@@ -31,6 +31,10 @@ class _Chrome:
                 "profile.content_settings": {"exceptions": {"mixed_script": {"*": {"setting": 1}}}},
             },
         )
+        if accept_insecure_certs:
+            self.options.set_capability("acceptInsecureCerts", accept_insecure_certs)
+        if headless:
+            self.options.add_argument("--headless=new")
 
     def install(self):
         """Installs the web driver"""
@@ -56,15 +60,19 @@ class _Chrome:
 class _Firefox:
     """Factory class for Firefox browser"""
 
-    def __init__(self, source, accept_insecure_certs, remote_url=None, binary_path=None):
+    # pylint: disable=too-many-arguments
+    def __init__(self, source, accept_insecure_certs, headless, remote_url=None, binary_path=None):
         self.source = source
         self.remote_url = remote_url
         self.binary_path = binary_path
         self.webdriver = None
         self.options = FirefoxOptions()
         self.options.set_preference("browser.link.open_newwindow", 3)
-        self.options.set_preference("webdriver_accept_untrusted_certs", accept_insecure_certs)
         self.options.set_preference("security.mixed_content.block_active_content", False)
+        if accept_insecure_certs:
+            self.options.set_preference("webdriver_accept_untrusted_certs", accept_insecure_certs)
+        if headless:
+            self.options.headless = True
 
     def install(self):
         """Installs the web driver"""
@@ -106,7 +114,7 @@ class ThreescaleWebdriver:
     """
 
     # pylint: disable=too-many-arguments
-    def __init__(self, driver, source, ssl_verify, remote_url=None, binary_path=None):
+    def __init__(self, driver, source, ssl_verify, headless=True, remote_url=None, binary_path=None):
         """
         Initializes factory with either specified or fetched from settings values.
         :param str driver: Browser name. One of ('chrome', 'firefox')
@@ -123,9 +131,9 @@ class ThreescaleWebdriver:
         accept_insecure_certs = not ssl_verify
 
         if self.driver == "chrome":
-            self.webdriver = _Chrome(source, accept_insecure_certs, remote_url, binary_path)
+            self.webdriver = _Chrome(source, accept_insecure_certs, headless, remote_url, binary_path)
         elif self.driver == "firefox":
-            self.webdriver = _Firefox(source, accept_insecure_certs, remote_url, binary_path)
+            self.webdriver = _Firefox(source, accept_insecure_certs, headless, remote_url, binary_path)
         else:
             raise ValueError(
                 '"{}" webdriver is not supported. Please use one of {}'.format(self.driver, ("chrome", "firefox"))


### PR DESCRIPTION
Added headless mode for UI tests and set it as default.
 
Using headless mode reduces the run time for UI tests by cca 42%