### PR TITLE
Add support for keycloak

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -29,9 +29,7 @@ pytest-asyncio = "*"
 requests = "*"
 3scale-api = ">=0.30.0"
 dynaconf = "*"
-# python_keycloak = "*"
-# Waiting for https://github.com/marcospereirampj/python-keycloak/pull/201 and https://github.com/marcospereirampj/python-keycloak/pull/200
-python-keycloak = ">=2.13"
+python-keycloak = "*"
 backoff = "*"
 websocket_client = "==1.5.1"
 httpx = {version = "*", extras = ["http2"]}

--- a/testsuite/rhsso/objects.py
+++ b/testsuite/rhsso/objects.py
@@ -2,7 +2,7 @@
 
 from urllib.parse import urlparse
 
-from keycloak import KeycloakAdmin, KeycloakOpenID
+from keycloak import KeycloakAdmin, KeycloakOpenID, KeycloakPostError
 
 
 class Realm:
@@ -16,7 +16,6 @@ class Realm:
             realm_name=name,
             user_realm_name="master",
             verify=False,
-            auto_refresh_token=["get", "put", "post", "delete"],
         )
         self.name = name
 
@@ -81,15 +80,24 @@ class RHSSO:
     def __init__(self, server_url, username, password) -> None:
         # python-keycloak API requires url to be pointed at auth/ endpoint
         # pylint: disable=protected-access
-        self.server_url = urlparse(server_url)._replace(path="auth/").geturl()
-        self.master = KeycloakAdmin(
-            server_url=self.server_url,
-            username=username,
-            password=password,
-            realm_name="master",
-            verify=False,
-            auto_refresh_token=["get", "put", "post", "delete"],
-        )
+        try:
+            self.master = KeycloakAdmin(
+                server_url=server_url,
+                username=username,
+                password=password,
+                realm_name="master",
+                verify=False,
+            )
+            self.server_url = server_url
+        except KeycloakPostError:
+            self.server_url = urlparse(server_url)._replace(path="auth/").geturl()
+            self.master = KeycloakAdmin(
+                server_url=self.server_url,
+                username=username,
+                password=password,
+                realm_name="master",
+                verify=False,
+            )
 
     def create_realm(self, name: str, **kwargs) -> Realm:
         """Creates new realm"""


### PR DESCRIPTION
Try to use the rhsso url as provided in config (expected path is '/'). Fallback to '/auth/' for backward compatibility with rhsso.

Remove constrain for python-keycloak >=2.13.

Removing auto_refresh_token due to:
  DeprecatedWarning: auto_refresh_token is deprecated as of 2.13.0 and will be
  removed in 4.0.0. Auto-refresh will be implicitly set for all requests