### PR TITLE
Search for deployments first, use dc as fallback

### DIFF
--- a/testsuite/dynaconf_loader.py
+++ b/testsuite/dynaconf_loader.py
@@ -60,6 +60,7 @@ def _guess_version(ocp, namespace):
     """Attempt to determine version from amp-system imagestream"""
 
     version = None
+    # TODO: ImageStreams are no longer used by 3scale; https://github.com/3scale-qe/3scale-tests/issues/816
     try:
         version = ocp.image_stream_tag_from_trigger("dc/apicast-production")
         Version(version)
@@ -99,8 +100,13 @@ def _guess_apicast_operator_version(ocp, settings):
 
 def _apicast_image(ocp):
     """Find source of amp-apicast image"""
-    lookup = ocp.do_action("get", ["dc/apicast-production", "-o", "yaml"], parse_output=True)
-    return lookup.model.spec.template.spec.containers[0].image
+    # dc are replaced with deployments in 2.15-dev
+    try:
+        lookup = ocp.do_action("get", ["deployment/apicast-production", "-o", "yaml"], parse_output=True)
+        return lookup.model.spec.template.spec.containers[0].image
+    except OpenShiftPythonException:
+        lookup = ocp.do_action("get", ["dc/apicast-production", "-o", "yaml"], parse_output=True)
+        return lookup.model.spec.template.spec.containers[0].image
 
 
 def _rhsso_password(server_url, token):

--- a/testsuite/gateways/apicast/__init__.py
+++ b/testsuite/gateways/apicast/__init__.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from typing import Optional, List, Dict, Tuple
 import logging
 
+from openshift_client import OpenShiftPythonException
+
 from threescale_api.resources import Service
 
 from testsuite.capabilities import Capability
@@ -82,7 +84,12 @@ class OpenshiftApicast(AbstractApicast, ABC):
     @property
     def deployment(self) -> Deployment:
         """Gateway deployment"""
-        return self.openshift.deployment(f"dc/{self.name}")
+        # dc are replaced with deployments in 2.15-dev
+        try:
+            self.openshift.do_action("get", [f"deployment/{self.name}"])
+            return self.openshift.deployment(f"deployment/{self.name}")
+        except OpenShiftPythonException:
+            return self.openshift.deployment(f"dc/{self.name}")
 
     def _routename(self, service):
         """name of route for given service"""

--- a/testsuite/gateways/apicast/operator.py
+++ b/testsuite/gateways/apicast/operator.py
@@ -4,6 +4,8 @@ import re
 import time
 from typing import Dict, Callable, Pattern, Any, Match, Union
 
+from openshift_client import OpenShiftPythonException
+
 from weakget import weakget
 
 from testsuite import settings
@@ -153,7 +155,12 @@ class OperatorApicast(OpenshiftApicast):
 
     @property
     def deployment(self):
-        return self.openshift.deployment(f"deployment/apicast-{self.name}")
+        # dc are replaced with deployments in 2.15-dev
+        try:
+            self.openshift.do_action("get", [f"deployment/apicast-{self.name}"])
+            return self.openshift.deployment(f"deployment/apicast-{self.name}")
+        except OpenShiftPythonException:
+            return self.openshift.deployment(f"dc/apicast-{self.name}")
 
     @property
     def environ(self) -> Properties:

--- a/testsuite/gateways/apicast/system.py
+++ b/testsuite/gateways/apicast/system.py
@@ -39,7 +39,13 @@ class SystemApicast(AbstractApicast):
     @property
     def deployment(self):
         """Return deployment config name of this apicast"""
-        return self.openshift.deployment("dc/apicast-staging" if self.staging else "dc/apicast-production")
+        # dc are replaced with deployments in 2.15-dev
+        name = "apicast-staging" if self.staging else "apicast-production"
+        try:
+            self.openshift.do_action("get", [f"deployment/{name}"])
+            return self.openshift.deployment(f"deployment/{name}")
+        except OpenShiftPythonException:
+            return self.openshift.deployment(f"dc/{name}")
 
     @property
     def environ(self) -> Properties:

--- a/testsuite/openshift/deployments.py
+++ b/testsuite/openshift/deployments.py
@@ -194,7 +194,11 @@ class KubernetesDeployment(Deployment):
     def get_pods(self):
         """Kubernetes Deployment doesnt have a nice universal way how to get the correct pods,
         so this method relies on pods having the deployment label"""
-        return self.openshift.select_resource("pods", labels={"deployment": self.name})
+
+        def select_pod(apiobject):
+            return apiobject.get_label("deployment") == self.name
+
+        return self.openshift.select_resource("pods", narrow_function=select_pod)
 
 
 class DeploymentConfig(Deployment):

--- a/testsuite/tests/apicast/parameters/test_modular_apicast.py
+++ b/testsuite/tests/apicast/parameters/test_modular_apicast.py
@@ -12,11 +12,13 @@ import backoff
 import importlib_resources as resources
 import pytest
 
+from openshift_client import OpenShiftPythonException
+
 from testsuite import rawobj
 from testsuite.capabilities import Capability
 from testsuite.gateways.apicast.operator import OperatorApicast
 from testsuite.gateways.apicast.template import TemplateApicast
-from testsuite.utils import blame
+from testsuite.utils import blame, warn_and_skip
 
 pytestmark = [
     pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT),
@@ -61,7 +63,11 @@ def set_gateway_image(openshift, staging_gateway, request, testconfig):
     github_template = resources.files("testsuite.resources.modular_apicast").joinpath("example_policy.yml")
     copy_template = resources.files("testsuite.resources.modular_apicast").joinpath("example_policy_copy.yml")
 
-    amp_release = openshift().image_stream_tag_from_trigger("dc/apicast-production")
+    try:
+        amp_release = openshift().image_stream_tag_from_trigger("dc/apicast-production")
+    except OpenShiftPythonException:
+        warn_and_skip("ImageStream not found.")
+
     project = openshift().project_name
     build_name_github = blame(request, "apicast-example-policy-github")
     build_name_copy = blame(request, "apicast-example-policy-copy")

--- a/testsuite/tests/apicast/parameters/test_policy_dependency.py
+++ b/testsuite/tests/apicast/parameters/test_policy_dependency.py
@@ -10,11 +10,13 @@ import pytest
 from lxml import etree
 from lxml.etree import XMLSyntaxError
 
+from openshift_client import OpenShiftPythonException
+
 from testsuite import rawobj
 from testsuite.capabilities import Capability
 from testsuite.gateways.apicast.operator import OperatorApicast
 from testsuite.gateways.apicast.template import TemplateApicast
-from testsuite.utils import blame
+from testsuite.utils import blame, warn_and_skip
 
 pytestmark = [
     pytest.mark.required_capabilities(Capability.STANDARD_GATEWAY, Capability.CUSTOM_ENVIRONMENT),
@@ -58,7 +60,11 @@ def set_gateway_image(openshift, staging_gateway, request, testconfig):
 
     template = resources.files("testsuite.resources.modular_apicast").joinpath("xml_policy.yml")
 
-    amp_release = openshift().image_stream_tag_from_trigger("dc/apicast-production")
+    try:
+        amp_release = openshift().image_stream_tag_from_trigger("dc/apicast-production")
+    except (OpenShiftPythonException, ValueError):
+        warn_and_skip("ImageStream not found.")
+
     project = openshift().project_name
     build_name = blame(request, "apicast-xml-policy")
 


### PR DESCRIPTION
With this changes, testsuite can be run with older builds which still use deploymintconfigs and works new builds which use deployments.