### PR TITLE
Export needs to be after variable is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,13 @@ SHELL = /bin/bash
 TB ?= short
 LOGLEVEL ?= INFO
 
-export resultsdir
-
 ifdef WORKSPACE  # Yes, this is for jenkins
 resultsdir = $(WORKSPACE)
 else
 resultsdir ?= .
 endif
+
+export resultsdir
 
 PIPENV_VERBOSITY ?= -1
 PIPENV_IGNORE_VIRTUALENVS ?= 1


### PR DESCRIPTION
before: 
```
make -n smoke
+ pipenv run python -m pytest --tb=short -o cache_dir=/.pytest_cache.smoke -p no:persistence -n6 -msmoke  testsuite
```

after: 
```
make -n smoke
+ pipenv run python -m pytest --tb=short -o cache_dir=./.pytest_cache.smoke -p no:persistence -n6 -msmoke  testsuite
```