### PR TITLE
Update to use offset-aware time objects

### DIFF
--- a/testsuite/gateway_logs.py
+++ b/testsuite/gateway_logs.py
@@ -1,6 +1,6 @@
 """Pytest plugin for collecting gateway logs"""
 
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 
 import pytest
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_setup(item):
     """Figures out what gateways are in use and when did he test setup started"""
-    start_time = datetime.utcnow()
+    start_time = datetime.now(timezone.utc)
     result = yield
 
     item.gateways = {}
@@ -38,7 +38,7 @@ def pytest_runtest_setup(item):
 def pytest_runtest_call(item):
     """Prints setup logs and figures out what gateways are in use and when did the test execution started"""
     # pylint: disable=protected-access
-    start_time = datetime.utcnow()
+    start_time = datetime.now(timezone.utc)
     yield
     _print_logs(item, start_time, "call", "test-run")
 
@@ -46,7 +46,7 @@ def pytest_runtest_call(item):
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_teardown(item):
     """Collect logs and add them to the output"""
-    start_time = datetime.utcnow()
+    start_time = datetime.now(timezone.utc)
     yield
     _print_logs(item, start_time, "teardown", "teardown")
 

--- a/testsuite/prometheus.py
+++ b/testsuite/prometheus.py
@@ -2,7 +2,7 @@
 
 import logging
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from math import ceil
 from typing import Optional, Callable, Dict
 from urllib.parse import urljoin
@@ -138,7 +138,7 @@ class PrometheusClient:
     def wait_on_next_scrape(self, target_container: str, after: Optional[datetime] = None):
         """Block until next scrape for a container is finished"""
         if after is None:
-            after = datetime.utcnow()
+            after = datetime.now(timezone.utc)
 
         def _time_of_scrape():
             for target in self.get_targets():
@@ -160,7 +160,7 @@ class PrometheusClient:
 
             till = last_scrape + timedelta(seconds=scrape_interval * num + 2)
 
-        wait_time = (till - datetime.utcnow()).seconds
+        wait_time = (till - datetime.now(timezone.utc)).seconds
         log.info("Waiting %ss for prometheus scrape", wait_time)
         time.sleep(wait_time)
 

--- a/testsuite/tests/apicast/policy/rate_limit/test_rate_limit_connection.py
+++ b/testsuite/tests/apicast/policy/rate_limit/test_rate_limit_connection.py
@@ -24,7 +24,7 @@ Actually this is 'scratched'. Does 'plain-to-plain' comparison make sense?
     spec/functional_specs/policies/rate_limit/connection/plain_text/true_condition/rate_limit_connection_service_true_spec.rb
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pprint import pformat
 import asyncio
 import random
@@ -132,7 +132,9 @@ async def get(client, limit_me, relpath):
     # let's spread requests over short period; avoid all at one moment
     await asyncio.sleep(random.uniform(0, WAIT - DELAY - 2))
 
-    return await client.get(relpath, headers={"X-Limit-Me": limit_me, "Date": datetime.utcnow().strftime(DATEFMT)})
+    return await client.get(
+        relpath, headers={"X-Limit-Me": limit_me, "Date": datetime.now(timezone.utc).strftime(DATEFMT)}
+    )
 
 
 @pytest.fixture

--- a/testsuite/tests/apicast/test_hit_limit.py
+++ b/testsuite/tests/apicast/test_hit_limit.py
@@ -13,7 +13,7 @@ After waiting for the time in the 'retry-after' header, the request should
 be accepted.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 import time
 
 import backoff
@@ -140,7 +140,7 @@ def test_retry_after(silver_client):
     """
 
     # wait for the beginning of next minute
-    time.sleep(61 - datetime.utcnow().second)
+    time.sleep(61 - datetime.now(timezone.utc).second)
 
     response = make_requests(silver_client)
 

--- a/testsuite/tests/prometheus/backend_listener/test_backend_listener_internal_api.py
+++ b/testsuite/tests/prometheus/backend_listener/test_backend_listener_internal_api.py
@@ -5,7 +5,7 @@ metric is expected
 """
 
 import base64
-from datetime import timedelta, datetime
+from datetime import timedelta, datetime, timezone
 from typing import Dict, Tuple
 
 import pytest
@@ -194,8 +194,7 @@ def test_internal_backend_listener(
 
     # wait to update metrics in prometheus
     # for some reason change is not visible right away, wait a little bit more here
-    prometheus.wait_on_next_scrape("backend-listener", datetime.utcnow() + timedelta(seconds=60))
-
+    prometheus.wait_on_next_scrape("backend-listener", datetime.now(timezone.utc) + timedelta(seconds=60))
     count_after = {}
     results = {}
 

--- a/testsuite/tests/system/analytics/test_infinite_time_range.py
+++ b/testsuite/tests/system/analytics/test_infinite_time_range.py
@@ -7,7 +7,7 @@ https://issues.redhat.com/browse/THREESCALE-6649
 Warning: due to the nature of the problem, test might produce false negatives, but it is better than having nothing
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from threescale_api.errors import ApiClientError
@@ -61,7 +61,7 @@ def test_application_usage(api_client, request, entity_type, entity, granularity
     """Tests that usage endpoints wont fail when supplied with ridiculous date ranges"""
     # To have some usage data
     api_client().get("/test")
-    yesterday = datetime.now() - timedelta(days=1)
+    yesterday = datetime.now(timezone.utc) - timedelta(days=1)
 
     entity_id = request.getfixturevalue(entity)["id"]
     # pylint: disable=protected-access

--- a/testsuite/utils.py
+++ b/testsuite/utils.py
@@ -1,7 +1,7 @@
 "testsuite helpers"
 
 import os
-import datetime
+from datetime import datetime, timezone
 import secrets
 import time
 import typing
@@ -104,7 +104,7 @@ def wait_interval(min_sec=15, max_sec=45):
     The requests has to be send between the 15th and 45th second of the minute
     When the time is outside of this interval, waits until the start of a next one
     """
-    seconds = datetime.datetime.now().second
+    seconds = datetime.now(timezone.utc).second
     if seconds < min_sec or seconds > max_sec:
         sleep_time = (60 - seconds + min_sec) % 60
         time.sleep(sleep_time)
@@ -115,7 +115,7 @@ def wait_until_next_minute(min_sec=15, max_sec=45):
     Waits until the start of the next minute when are the limits reseted,
     then waits until the start of the interval allowed to sent requests
     """
-    seconds = datetime.datetime.now().second
+    seconds = datetime.now(timezone.utc).second
     time.sleep(60 - seconds)
     if min_sec < seconds < max_sec:
         wait_interval()
@@ -126,7 +126,7 @@ def wait_interval_hour(max_min, min_min=0):
     Prevents sending the request in the beginning or at the end of an hour
     Prevents refreshing the limits during the test
     """
-    minutes = datetime.datetime.now().minute
+    minutes = datetime.now(timezone.utc).minute
     if minutes < min_min or minutes > max_min:
         sleep_time = ((60 - minutes + min_min) % 60) * 60 + 10
         time.sleep(sleep_time)


### PR DESCRIPTION
When using python 3.12 Deprication warrning is shown

`DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).`