### PR TITLE
Make more general selector for 3scale and apicast operators

### DIFF
--- a/testsuite/openshift/client.py
+++ b/testsuite/openshift/client.py
@@ -230,8 +230,12 @@ class OpenShiftClient:
 
         def select_operator(apiobject):
             return (
-                apiobject.get_label("com.redhat.component-name") == "3scale-operator"
-                or apiobject.get_label("rht.subcomp") == "3scale_operator"
+                apiobject.get_label("com.redhat.component-name", "").lower() == "3scale-operator"
+                or apiobject.get_label("rht.subcomp", "").lower() == "3scale_operator"
+                or (
+                    apiobject.get_label("control-plane", "").lower() == "controller-manager"
+                    and apiobject.get_label("app", "").lower() == "3scale-api-management"
+                )
             )
 
         return self.select_resource("pods", narrow_function=select_operator).object(cls=Operator)
@@ -246,8 +250,12 @@ class OpenShiftClient:
 
         def select_operator(apiobject):
             return (
-                apiobject.get_label("com.redhat.component-name") == "apicast-operator"
-                or apiobject.get_label("rht.subcomp") == "apicast_operator"
+                apiobject.get_label("com.redhat.component-name", "").lower() == "apicast-operator"
+                or apiobject.get_label("rht.subcomp", "").lower() == "apicast_operator"
+                or (
+                    apiobject.get_label("control-plane", "").lower() == "controller-manager"
+                    and apiobject.get_label("app", "").lower() == "apicast"
+                )
             )
 
         return self.select_resource("pods", narrow_function=select_operator).object(cls=Operator)


### PR DESCRIPTION
in case some builds does not have "rht.subcomp"