### PR TITLE
Fix test metrics hierarchies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ types-braintree = "*"
 types-stripe = "*"
 types-Pillow = "*"
 black = "*"
-types-retry = "*"
 # Have commented out python-language-server to make it available quickly
 # for the development
 #python-language-server = "*"
@@ -59,7 +58,6 @@ pytest-persistence = "*"
 pytest-metadata = ">=3.0.0"
 pytest-html = "*"
 ansi2html = "*"
-retry = "==0.9.2"
 
 [requires]
 python_version = "3"

--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ types-braintree = "*"
 types-stripe = "*"
 types-Pillow = "*"
 black = "*"
+types-retry = "*"
 # Have commented out python-language-server to make it available quickly
 # for the development
 #python-language-server = "*"
@@ -58,6 +59,7 @@ pytest-persistence = "*"
 pytest-metadata = ">=3.0.0"
 pytest-html = "*"
 ansi2html = "*"
+retry = "==0.9.2"
 
 [requires]
 python_version = "3"


### PR DESCRIPTION
Error was caused by deletion of custom_ui_backend while it was still registered in custom_ui_product.
This fix assures, that teardown of custom_ui_product fixtures will be executed before teardown of custom_ui_backend.