### PR TITLE
Bump python-keycloak version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -29,7 +29,7 @@ pytest-asyncio = "==0.21.2"
 requests = "*"
 3scale-api = ">=0.35.0"
 dynaconf = "*"
-python-keycloak = "==4.0.1"
+python-keycloak = ">=4.7.3"  # this fix needed: https://github.com/marcospereirampj/python-keycloak/pull/622/files
 backoff = "*"
 websocket_client = "==1.5.1"
 httpx = {version = "*", extras = ["http2"]}

--- a/testsuite/rhsso/__init__.py
+++ b/testsuite/rhsso/__init__.py
@@ -33,7 +33,7 @@ class RHSSOServiceConfiguration:
         """OIDCClient for the created client"""
         if not self._oidc_client:
             self._oidc_client = self.client.oidc_client
-        return self._oidc_client
+        return self._oidc_client  # type: ignore
 
     def issuer_url(self) -> str:
         """


### PR DESCRIPTION
There was this bug: https://github.com/marcospereirampj/python-keycloak/issues/623, which was fixed since version 4.7.3 by this PR: https://github.com/marcospereirampj/python-keycloak/pull/622/files