### PR TITLE
Fix fake-sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -304,6 +304,7 @@ ensure-smoke:
 
 fake-sync:
 	test -e Pipfile.lock \
+		&& (pipenv --venv || pipenv sync --dev $(PIPENV_ARGS)) \
 		&& touch Pipfile.lock \
 		&& touch .make-pipenv-sync .make-pipenv-sync-dev \
 		|| true


### PR DESCRIPTION
acceptance action failed if it ran against tag (with Pipenv.lock) and github cache of pipenv was not present.