### PR TITLE
Revert "Bump python-keycloak version"

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -29,7 +29,7 @@ pytest-asyncio = "==0.21.2"
 requests = "*"
 3scale-api = ">=0.35.0"
 dynaconf = "*"
-python-keycloak = ">=4.7.3"  # this fix needed: https://github.com/marcospereirampj/python-keycloak/pull/622/files
+python-keycloak = "==4.0.1"
 backoff = "*"
 websocket_client = "==1.5.1"
 httpx = {version = "*", extras = ["http2"]}

--- a/testsuite/rhsso/__init__.py
+++ b/testsuite/rhsso/__init__.py
@@ -33,7 +33,7 @@ class RHSSOServiceConfiguration:
         """OIDCClient for the created client"""
         if not self._oidc_client:
             self._oidc_client = self.client.oidc_client
-        return self._oidc_client  # type: ignore
+        return self._oidc_client
 
     def issuer_url(self) -> str:
         """


### PR DESCRIPTION
This reverts commit f0d65e0e63e20b8e085e45f63e1512037014d0e6.

`make check` fails on RHSSO 7.6.11.GA deployed by operator