### PR TITLE
change to rhbk v26 health check

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -20,7 +20,6 @@ default:
         kind: "SystemApicast"
   rhsso:
     kind: rhbk
-    username: admin
     test_user:
       username: testUser
       password: testUser

--- a/config/settings.yaml.tpl
+++ b/config/settings.yaml.tpl
@@ -40,6 +40,8 @@ default:
         name: "{DEFAULT_OPENSHIFT_THREESCALE_PROJECT}"
   rhsso:
     kind: rhbk # rhbk is deault; other acceptable value is rhsso
+    username: admin # auto-discovered, might be overitten here
+    password: admin-pass # auto-discovered, might be overitten here
     test_user:
       username: testUser
       password: testUser

--- a/testsuite/tests/tools/test_tool_availability.py
+++ b/testsuite/tests/tools/test_tool_availability.py
@@ -51,7 +51,7 @@ def test_sso_availability(rhsso_kind, rhsso_service_info: RHSSOServiceConfigurat
     """
     endpoint = rhsso_service_info.rhsso.server_url
     if rhsso_kind == "rhbk":
-        endpoint = endpoint + "/health"
+        endpoint = endpoint.replace("no-ssl-rhbk", "no-ssl-rhbk-management") + "/health"
     response = requests.get(endpoint, verify=False)
     assert response.status_code == 200
     if rhsso_kind == "rhbk":


### PR DESCRIPTION
With update https://github.com/3scale-qe/tools/pull/57, health endpoint is served on management port 