### PR TITLE
Fix analytics test timing issue that appeared on alpha build

### DIFF
--- a/testsuite/tests/ui/analytics/test_analytics.py
+++ b/testsuite/tests/ui/analytics/test_analytics.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from wait_for import wait_for, TimedOutError
 from testsuite import rawobj
 from testsuite.ui.views.admin.backend.analytics import BackendTrafficView
 from testsuite.ui.views.admin.product.analytics import ProductTrafficView
@@ -68,6 +69,11 @@ def test_analytics(navigator, service, api_client, backend_anything, backend_val
     assert traffic.read_metric() == 1
 
     traffic.select_metric("hits")
+    # Wait for the metric to update from initial value, then verify it's correct
+    try:
+        wait_for(lambda: traffic.read_metric() != 1, timeout="3s", delay=0.2)
+    except TimedOutError:
+        pass  # Metric didn't update after timeout, pytest assertion will fail
     assert traffic.read_metric() == 5
 
     traffic = navigator.navigate(BackendTrafficView, backend=backend_anything)


### PR DESCRIPTION
  The analytics.py test was failing on alpha build due to some timing differences in data loading.
  
  Adding a try/except block and lambda function to allow time for loading timing differences between alpha build and GA build.

  The test now waits (max of 3 seconds with periodic checks) for the metric value to update.
  
  Tested and passing successfully on both alpha build and GA build. 