### PR TITLE
Adding waits to resolve timing issues on test_devel_sections.py

### DIFF
--- a/testsuite/tests/ui/devel/test_devel_sections.py
+++ b/testsuite/tests/ui/devel/test_devel_sections.py
@@ -1,5 +1,6 @@
 """Test for developer portal sections"""
 
+import backoff
 import pytest
 from packaging.version import Version  # noqa # pylint: disable=unused-import
 
@@ -14,6 +15,12 @@ from testsuite.ui.views.admin.audience.developer_portal import (
 )
 from testsuite.ui.views.common.foundation import NotFoundView
 from testsuite.utils import blame
+
+pytestmark = [
+    pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-9020"),
+    pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-836"),
+    pytest.mark.skipif(TESTED_VERSION < Version("2.14-dev"), reason="Requires 3scale >= 2.14"),
+]
 
 
 @pytest.fixture(scope="module")
@@ -67,9 +74,7 @@ def dev_portal_group(navigator, request, account, dev_portal_section, custom_adm
     view.update([group_name])
 
 
-@pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-9020")
-@pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-836")
-@pytest.mark.skipif("TESTED_VERSION < Version('2.14-dev')")
+@backoff.on_exception(backoff.fibo, AssertionError, max_tries=5, jitter=None)
 @pytest.mark.usefixtures("dev_portal_group")
 @pytest.mark.usefixtures("login")
 def test_dev_portal_sections(account, custom_devel_login, browser, testconfig, dev_portal_page):
@@ -85,11 +90,13 @@ def test_dev_portal_sections(account, custom_devel_login, browser, testconfig, d
         - Assert that this account hasn't access to this page
     """
     custom_devel_login(account=account)
+
     browser.url = testconfig["threescale"]["devel"]["url"] + dev_portal_page
 
     assert browser.element(".//h1").accessible_name == "Test"
 
     custom_devel_login(name="john", password="123456", fresh=True)
+
     browser.url = testconfig["threescale"]["devel"]["url"] + dev_portal_page
 
     assert NotFoundView(browser).is_displayed

--- a/testsuite/tests/ui/devel/test_devel_sections.py
+++ b/testsuite/tests/ui/devel/test_devel_sections.py
@@ -90,13 +90,11 @@ def test_dev_portal_sections(account, custom_devel_login, browser, testconfig, d
         - Assert that this account hasn't access to this page
     """
     custom_devel_login(account=account)
-
     browser.url = testconfig["threescale"]["devel"]["url"] + dev_portal_page
 
     assert browser.element(".//h1").accessible_name == "Test"
 
     custom_devel_login(name="john", password="123456", fresh=True)
-
     browser.url = testconfig["threescale"]["devel"]["url"] + dev_portal_page
 
     assert NotFoundView(browser).is_displayed


### PR DESCRIPTION
- Tests were failing ~50/60% of the time due to race condition/timing issue in dev portal
- Using @backoff to retry on failed assertions. Pytestmark added to facilitate backoff decorator. 
- Reliability of test greatly improved with this change. No fails observed locally after addition of wait times.
