### PR TITLE
Adding explicit call for apicast-production metrics

### DIFF
--- a/testsuite/tests/prometheus/apicast/test_metrics.py
+++ b/testsuite/tests/prometheus/apicast/test_metrics.py
@@ -40,9 +40,36 @@ STATUSES = [300, 418, 507]
 
 
 # pylint: disable=unused-argument
-@pytest.fixture(scope="module", params=["apicast-staging", "apicast-production"])
-def metrics(request, prometheus):
+@pytest.fixture(
+    scope="module", params=["apicast-staging", pytest.param("apicast-production", marks=pytest.mark.disruptive)]
+)
+def metrics(request, prometheus, application, api_client):
     """Return all metrics from target defined of staging and also production apicast."""
+    # Check if any required metrics don't exist
+    existing_metrics = get_metrics_keys(prometheus.get_metrics(labels={"container": request.param}))
+
+    required_standard_metrics = ["threescale_backend_calls", "upstream_status", "apicast_status"]
+    required_histogram_metrics = ["total_response_time_seconds", "upstream_response_time_seconds"]
+
+    standard_missing = any(metric not in existing_metrics for metric in required_standard_metrics)
+
+    histogram_missing = any(
+        f"{metric}_{suffix}" not in existing_metrics
+        for metric in required_histogram_metrics
+        for suffix in ["_bucket", "_sum", "_count"]
+    )
+
+    # If some metrics do not exist, trigger with explicit HTTP request
+    if standard_missing or histogram_missing:
+        if request.param == "apicast-production":
+            prod_client = request.getfixturevalue("prod_client")
+            client = prod_client()
+        else:
+            client = api_client()
+
+        client.get("/get")
+        prometheus.wait_on_next_scrape(request.param)
+
     metrics = get_metrics_keys(prometheus.get_metrics(labels={"container": request.param}))
     return metrics
 
@@ -88,9 +115,10 @@ def test_apicast_status_metrics(request, client, container, prometheus):
 
     Apicast logs http status codes on prometheus as a counter.
     """
-
-    client = request.getfixturevalue(client)
-    client = client()
+    if client == "prod_client":
+        client = request.getfixturevalue(client)(promote=False)
+    else:
+        client = request.getfixturevalue(client)()
 
     for status in STATUSES:
         assert client.get(f"/status/{status}").status_code == status


### PR DESCRIPTION
- The test queries Prometheus for metrics for "apicast-staging" and "apicast-production"
- Since production has never received HTTP traffic, request-dependent metrics don't exist and the test fails 
- For production metrics, promotes staging config to production and sends a GET request to /get endpoint 
- This generates the missing metrics (apicast_status, upstream_status, threescale_backend_calls, and response time histograms - **5 tests now passing**)
- prometheus.wait_on_next_scrape so that metrics appear in db, as seen elsewhere for prometheus/apicast in testsuite
- All metrics passing on Alpha with this change, but considerable increase in test time (now ~4 mins)
- Marking apicast-prodiuction as disruptive to ensure apicast restart does not impact other tests. 
- Adding idempotent check to prod_client fixture to prevent duplicate promotion errors