### PR TITLE
Add backoff retry for RHSSO and Content Limits tests 

### DIFF
--- a/testsuite/tests/apicast/auth/rhsso/openid_rhsso/conftest.py
+++ b/testsuite/tests/apicast/auth/rhsso/openid_rhsso/conftest.py
@@ -2,6 +2,7 @@
 Conftest for the openid rhsso credentials locations tests
 """
 
+import backoff
 import pytest
 
 
@@ -14,6 +15,21 @@ def staging_client(api_client):
     """
     client = api_client()
     client.auth = None
+
+    original_get = client.get
+    original_post = client.post
+
+    @backoff.on_predicate(backoff.expo, lambda x: x.status_code == 404, max_tries=10, max_time=60)
+    def get_with_retry(*args, **kwargs):
+        return original_get(*args, **kwargs)
+
+    @backoff.on_predicate(backoff.expo, lambda x: x.status_code == 404, max_tries=10, max_time=60)
+    def post_with_retry(*args, **kwargs):
+        return original_post(*args, **kwargs)
+
+    client.get = get_with_retry
+    client.post = post_with_retry
+
     return client
 
 

--- a/testsuite/tests/apicast/policy/content_limits/conftest.py
+++ b/testsuite/tests/apicast/policy/content_limits/conftest.py
@@ -1,0 +1,29 @@
+"""
+Conftest for payload limits
+"""
+
+import backoff
+import pytest
+
+
+@pytest.fixture(scope="module")
+def api_client(api_client):
+    """
+    Wrap api_client with a backoff retry on 404 to handle race conditions
+    where APIcast staging hasn't loaded the new service configuration yet
+    """
+
+    def _api_client_with_retry(**kwargs):
+        client = api_client(**kwargs)
+
+        original_get = client.get
+
+        @backoff.on_predicate(backoff.expo, lambda x: x.status_code == 404, max_tries=10, max_time=100)
+        def get_with_retry(*args, **kwargs):
+            return original_get(*args, **kwargs)
+
+        client.get = get_with_retry
+
+        return client
+
+    return _api_client_with_retry


### PR DESCRIPTION
  - Add `@backoff` decorator to `staging_client` fixture
  - RHSSO tests have been failing frequently on Jenkins pipeline runs for Alpha build
  - Same fix added for `payload_limits`, flaky on Jenkins pipeline
  - The tests will now retry on 404 status (config not loaded yet)
  - Should fix timing issues in CI/Jenkins where APIcast staging hasn't polled configuration yet