### PR TITLE
Change to resolve 404s seen in RHSSO tests on Jenkins pipeline

### DIFF
--- a/testsuite/tests/apicast/auth/rhsso/openid_rhsso/conftest.py
+++ b/testsuite/tests/apicast/auth/rhsso/openid_rhsso/conftest.py
@@ -12,9 +12,7 @@ def staging_client(api_client):
     The auth of the session is set up to none in order to test different auth methods
     The auth of the request will be passed in test functions
     """
-    client = api_client()
-    client.auth = None
-    return client
+    return api_client()
 
 
 @pytest.fixture(scope="module")
@@ -24,9 +22,7 @@ def production_client(prod_client):
     The auth of the session is set up to none in order to test different auth methods
     The auth of the request will be passed in test functions
     """
-    client = prod_client()
-    client.auth = None
-    return client
+    return prod_client()
 
 
 @pytest.fixture

--- a/testsuite/tests/apicast/auth/rhsso/openid_rhsso/test_openid_rhsso_basic_auth.py
+++ b/testsuite/tests/apicast/auth/rhsso/openid_rhsso/test_openid_rhsso_basic_auth.py
@@ -42,6 +42,7 @@ def test_access_token(token):
 def test_token_basic_auth(request, client_function, token):
     """Test checks if the request with access token using basic auth will fail on both apicasts"""
     client = request.getfixturevalue(client_function)
+    client.auth = None
     response = client.get("/get", headers={"authorization": "Bearer " + token})
     assert response.status_code == 200
 
@@ -62,6 +63,7 @@ def test_token_basic_auth(request, client_function, token):
 def test_token_in_query(request, client_function, token):
     """Test checks if the request with access token in query params will succeed on both apicasts."""
     client = request.getfixturevalue(client_function)
+    client.auth = None
     response = client.get("/get", params={"access_token": token})
     assert response.status_code == 403
 
@@ -79,6 +81,7 @@ def test_token_in_query(request, client_function, token):
 def test_token_headers(request, client_function, token):
     """Test checks if the request with access token using basic auth will fail on both apicasts"""
     client = request.getfixturevalue(client_function)
+    client.auth = None
     response = client.get("/get", headers={"access_token": token})
     assert response.status_code == 403
 
@@ -96,6 +99,7 @@ def test_token_headers(request, client_function, token):
 def test_invalid_token_basic_auth(request, client_function):
     """Test checks if the request with access token using basic auth will fail on both apicasts"""
     client = request.getfixturevalue(client_function)
+    client.auth = None
     response = client.get("/get", headers={"authorization": "Bearer " + "NotValidAccessToken"})
     assert response.status_code == 403
 
@@ -113,6 +117,7 @@ def test_invalid_token_basic_auth(request, client_function):
 def test_client_id_and_secret_in_query(request, client_function, application):
     """Test checks if the request with client id and client secret in the query params will fail on both apicasts"""
     client = request.getfixturevalue(client_function)
+    client.auth = None
     response = client.get(
         "/get", params={"client_id": application["client_id"], "client_secret": application["client_secret"]}
     )

--- a/testsuite/tests/apicast/auth/rhsso/openid_rhsso/test_openid_rhsso_headers.py
+++ b/testsuite/tests/apicast/auth/rhsso/openid_rhsso/test_openid_rhsso_headers.py
@@ -42,6 +42,7 @@ def test_access_token(token):
 def test_token_headers(request, client_function, token):
     """Test checks if the request with access token using headers will succeed on both apicasts"""
     client = request.getfixturevalue(client_function)
+    client.auth = None
     response = client.get("/get", headers={"access_token": token})
     assert response.status_code == 200
 
@@ -64,6 +65,7 @@ def test_token_headers(request, client_function, token):
 def test_token_in_query(request, client_function, token):
     """Test checks if the request with access token in query params will fail on both apicasts."""
     client = request.getfixturevalue(client_function)
+    client.auth = None
     response = client.get("/get", params={"access_token": token})
     assert response.status_code == 403
 
@@ -83,6 +85,7 @@ def test_token_in_query(request, client_function, token):
 def test_token_basic_auth(request, client_function, token):
     """Test checks if the request with access token using basic auth will fail on both apicasts"""
     client = request.getfixturevalue(client_function)
+    client.auth = None
     response = client.get("/get", headers={"authorization": "Bearer " + token})
     assert response.status_code == 403
 
@@ -100,6 +103,7 @@ def test_token_basic_auth(request, client_function, token):
 def test_invalid_token_in_headers(request, client_function):
     """Test checks if the request with invalid access token in headers will fail on both apicasts."""
     client = request.getfixturevalue(client_function)
+    client.auth = None
     response = client.get("/get", headers={"access_token": "NotValidAccessToken"})
     assert response.status_code == 403
 
@@ -117,6 +121,7 @@ def test_invalid_token_in_headers(request, client_function):
 def test_client_id_and_secret_in_query(request, client_function, application):
     """Test checks if the request with client id and client secret in the query params will fail on both apicasts"""
     client = request.getfixturevalue(client_function)
+    client.auth = None
     response = client.get(
         "/get", params={"client_id": application["client_id"], "client_secret": application["client_secret"]}
     )

--- a/testsuite/tests/apicast/auth/rhsso/openid_rhsso/test_openid_rhsso_query.py
+++ b/testsuite/tests/apicast/auth/rhsso/openid_rhsso/test_openid_rhsso_query.py
@@ -42,6 +42,7 @@ def test_access_token(token):
 def test_token_in_query(request, client_function, token):
     """Test checks if the request with access token in query params will succeed on both apicasts."""
     client = request.getfixturevalue(client_function)
+    client.auth = None
     response = client.get("/get", params={"access_token": token})
     assert response.status_code == 200
 
@@ -64,6 +65,7 @@ def test_token_in_query(request, client_function, token):
 def test_token_basic_auth(request, client_function, token):
     """Test checks if the request with access token in the basic auth will fail on both apicasts."""
     client = request.getfixturevalue(client_function)
+    client.auth = None
     response = client.get("/get", headers={"authorization": "Bearer " + token})
     assert response.status_code == 403
 
@@ -81,6 +83,7 @@ def test_token_basic_auth(request, client_function, token):
 def test_token_headers(request, client_function, token):
     """Test checks if the request with access token using headers will fail on both apicasts"""
     client = request.getfixturevalue(client_function)
+    client.auth = None
     response = client.get("/get", headers={"access_token": token})
     assert response.status_code == 403
 
@@ -98,6 +101,7 @@ def test_token_headers(request, client_function, token):
 def test_invalid_token_in_query(request, client_function):
     """Test checks if the request with invalid access token in query params will fail on both apicasts."""
     client = request.getfixturevalue(client_function)
+    client.auth = None
     response = client.get("/get", params={"access_token": "NotValidAccessToken"})
     assert response.status_code == 403
 
@@ -115,6 +119,7 @@ def test_invalid_token_in_query(request, client_function):
 def test_client_id_and_secret_in_query(request, client_function, application):
     """Test checks if the request with client id and client secret in the query params will fail on both apicasts"""
     client = request.getfixturevalue(client_function)
+    client.auth = None
     response = client.get(
         "/get", params={"client_id": application["client_id"], "client_secret": application["client_secret"]}
     )


### PR DESCRIPTION
- Refactoring #1022 (now closed)
- Custom `@backoff` removed from RHSSO tests in favour of built-in retries for 404/503s
- `api_client` and `prod_client` are module scoped, should prevent double promotion in production 
- Explicit `client.auth = None` for each test. Will need to validate built-in retry using Jenkins pipeline. 