### PR TITLE
Update junit2reportportal to use new plugin API endpoint

### DIFF
--- a/scripts/junit2reportportal
+++ b/scripts/junit2reportportal
@@ -59,6 +59,8 @@ token = os.environ[args.token_variable]
 reportportal = args.reportportal.rstrip("/")
 
 auth = {"Authorization": f"Bearer {token}"}
-launch_import = f"{reportportal}/api/v1/{args.project}/launch/import"
+launch_import = f"{reportportal}/api/v1/plugin/{args.project}/junit/import"
 
-print(requests.post(launch_import, files={"file": (f"{args.launch_name}.zip", stream.getbuffer(), "application/zip")}, headers=auth).text)
+print(requests.post(launch_import, files={"file": (f"{args.launch_name}.zip", stream.getbuffer(), "application/zip"),
+                                          "launchImportRq": (None, f'{{"name": "{args.launch_name}"}}', "application/json")},
+                    headers=auth).text)


### PR DESCRIPTION
Switch from /api/v1/{project}/launch/import to /api/v1/plugin/{project}/junit/import and add launchImportRq JSON part with launch name to the multipart request.