### PR TITLE
Test Updates to Align with Header Removal from APIcast Midstream

### DIFF
--- a/testsuite/tests/apicast/policy/on_failed/test_onfailed.py
+++ b/testsuite/tests/apicast/policy/on_failed/test_onfailed.py
@@ -54,7 +54,7 @@ def status_code(chain_name, on_failed_configuration) -> int:
 
 @backoff.on_predicate(
     backoff.fibo,
-    lambda response: response.headers.get("server") not in ("openresty", "envoy"),
+    lambda response: response.status_code not in (200, 503, 500),
     max_tries=8,
     jitter=None,
 )
@@ -72,4 +72,3 @@ def test_on_failed_policy(application, status_code):
 
     response = make_request(api_client)
     assert response.status_code == status_code
-    assert response.headers["server"] in ("openresty", "envoy")

--- a/testsuite/tests/apicast/policy/on_failed/test_onfailed.py
+++ b/testsuite/tests/apicast/policy/on_failed/test_onfailed.py
@@ -52,15 +52,16 @@ def status_code(chain_name, on_failed_configuration) -> int:
     return on_failed_configuration.get("error_status_code", 503)
 
 
-@backoff.on_predicate(
-    backoff.fibo,
-    lambda response: response.status_code not in (200, 503, 500),
-    max_tries=8,
-    jitter=None,
-)
-def make_request(api_client):
+def make_request(api_client, expected_code):
     """Make request to the product and retry if the response isn't from APIcast"""
-    return api_client.get("/")
+
+    @backoff.on_predicate(
+        backoff.fibo, lambda response: response.status_code != expected_code, max_tries=8, jitter=None
+    )
+    def _request():
+        return api_client.get("/")
+
+    return _request()
 
 
 def test_on_failed_policy(application, status_code):
@@ -70,5 +71,5 @@ def test_on_failed_policy(application, status_code):
     """
     api_client = application.api_client(disable_retry_status_list=(503,))
 
-    response = make_request(api_client)
+    response = make_request(api_client, status_code)
     assert response.status_code == status_code

--- a/testsuite/tests/apicast/test_do_not_send_openresty_version.py
+++ b/testsuite/tests/apicast/test_do_not_send_openresty_version.py
@@ -29,9 +29,7 @@ def client(api_client):
     return api_client(disable_retry_status_list={503, 404})
 
 
-@backoff.on_predicate(
-    backoff.fibo, lambda x: x.headers.get("server", "") not in ("openresty", "envoy"), max_tries=8, jitter=None
-)
+@backoff.on_predicate(backoff.fibo, lambda x: x.status_code != 503, max_tries=8, jitter=None)
 def make_requests(client):
     """Make sure that we get 503 apicast (backend is not available)"""
     return client.get("/anything")
@@ -41,15 +39,14 @@ def make_requests(client):
 def test_do_not_send_openresty_version(client):
     """
     Make request to non existing endpoint
-    Assert that the response does not contain openresty version in the headers
+    Assert that any server header (including envoy) does not contain "/", indicating version
     Assert that the response does not contain openresty version in the body
     """
     response = make_requests(client)
     assert response.status_code == 503
 
-    assert "server" in response.headers
-    if response.headers["server"] == "envoy":
-        pytest.skip("envoy edge proxy in use")
-    assert response.headers["server"] == "openresty"
+    server_header = response.headers.get("server", "")
+    if server_header:
+        assert "/" not in server_header
 
-    assert "<center>openresty</center>" in response.text
+    assert "openresty/" not in response.text


### PR DESCRIPTION
- APIcast midstream update removes the Server header from HTTP responses. This breaks tests that rely on checking headers to confirm APIcast is responding.
- Update to the backoff mechanism to look for valid response code rather than server header. Ensures backoff logic remains in place and working, in case it is needed. 
- `test_do_not_send_openresty_version.py‎` also affected by midstream change. 
- Test now verifies that no server header or version information is disclosed anywhere.