### PR TITLE
Update MailhogClient method call in test_message_counter.py

### DIFF
--- a/testsuite/tests/ui/mail_and_messages/test_message_counter.py
+++ b/testsuite/tests/ui/mail_and_messages/test_message_counter.py
@@ -65,7 +65,7 @@ def test_message_counter(
         send_message_from_devel(navigator, subjects[0], contents[0])
         send_message_from_devel(navigator, subjects[1], contents[1])
     finally:
-        mailhog_client.find_message(
+        mailhog_client.find_messages(
             subject=f"New message from {account.entity_name}"
         )  # assure that messages will be deleted if skip_cleanup is false
 


### PR DESCRIPTION
- MailHog method update triggering fails on Alpha build
- Method name updated from `find_message()` to `find_messages()` in test_message_counter.py
- Relates to https://github.com/3scale-qe/3scale-tests/pull/1015 in which method was renamed 