### PR TITLE
Add `container-image-temp` that will build and tag image for expiration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,10 @@ container-image: IMAGENAME ?= 3scale-tests
 container-image: fetch-tools
 	docker build -t $(IMAGENAME) $(DOCKER_BUILD_ARGS) .
 
+container-image-temp: ## Build container image that expires on quay.io in 7 days
+container-image-temp: DOCKER_BUILD_ARGS += --label quay.expires-after=7d
+container-image-temp: container-image
+
 clean: ## Clean pip deps
 clean: mostlyclean
 	rm -f Pipfile.lock


### PR DESCRIPTION
when building testing images and pushing them to quay, this will ensure that such temp images will not stay in quay.io registry