### PR TITLE
User permissions test

### DIFF
--- a/testsuite/tests/ui/users_and_roles/conftest.py
+++ b/testsuite/tests/ui/users_and_roles/conftest.py
@@ -1,0 +1,33 @@
+"""Conftest for user permissions tests"""
+
+import pytest
+from selenium.common.exceptions import NoSuchElementException, WebDriverException
+from widgetastic.widget import GenericLocatorWidget
+
+
+@pytest.fixture
+def is_page_accessible():
+    """
+    Helper function for permission tests to check if a page is accessible.
+
+    This checks for successful page access by verifying:
+    1. Correct URL path is loaded
+    2. The masthead header is present (exists on all allowed pages, not on access denied)
+    """
+
+    def _check(page):
+        if page.path not in page.browser.url:
+            return False
+
+        try:
+            masthead = GenericLocatorWidget(
+                page, locator="//header[contains(@class, 'pf-c-masthead') and contains(@class, 'pf-m-display-inline')]"
+            )
+            if not masthead.is_displayed:
+                return False
+        except (NoSuchElementException, WebDriverException):
+            return False
+
+        return True
+
+    return _check

--- a/testsuite/tests/ui/users_and_roles/test_permissions.py
+++ b/testsuite/tests/ui/users_and_roles/test_permissions.py
@@ -2,76 +2,68 @@
 
 import pytest
 
-from testsuite.ui.views.admin.audience.billing import BillingSettingsView, BillingView
+from testsuite.ui.views.admin.audience.account import AccountsView
+from testsuite.ui.views.admin.audience.billing import (
+    BillingSettingsView,
+    BillingView,
+)
 from testsuite.ui.views.admin.audience.developer_portal import (
     ActiveDocsView,
     CMSNewPageView,
     CMSNewSectionView,
     DeveloperPortalContentView,
 )
+from testsuite.ui.views.admin.backend.analytics import BackendTrafficView
 from testsuite.ui.views.admin.foundation import AccessDeniedView
 
-PERMISSION_DICT = [
-    pytest.param("portal", DeveloperPortalContentView),
-    pytest.param("portal", DeveloperPortalContentView),
-    pytest.param("portal", CMSNewPageView),
-    pytest.param("portal", CMSNewSectionView),
-    pytest.param("finance", BillingView),
-    pytest.param(
-        "finance",
-        BillingSettingsView,
-        marks=[pytest.mark.xfail, pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-10995")],
-    ),
-    pytest.param("plans", ActiveDocsView),
+PERMISSIONS = ["portal", "finance", "settings", "partners", "monitoring", "plans", "policy_registry"]
+
+VIEWS = [
+    ("portal", DeveloperPortalContentView),
+    ("portal", CMSNewPageView),
+    ("portal", CMSNewSectionView),
+    ("finance", BillingView),
+    ("finance", BillingSettingsView),
+    ("plans", ActiveDocsView),
+    ("monitoring", BackendTrafficView),
+    ("partners", AccountsView),
 ]
 
 
-@pytest.fixture()
-def all_page_objects():
-    """Returns all page objects from permissions tuple filtered of views with same permission"""
-
-    def _all_page_objects(except_permission, current_view):
-
-        all_views = [
-            view
-            for perm, view in [param.values for param in PERMISSION_DICT]
-            if perm != except_permission or view == current_view
-        ]
-
-        return all_views
-
-    return _all_page_objects
-
-
 # pylint: disable=too-many-arguments
-@pytest.mark.parametrize("permission, page_view", PERMISSION_DICT)
+@pytest.mark.parametrize("user_permission", PERMISSIONS)
+@pytest.mark.parametrize("required_permission, page_view", VIEWS)
 def test_member_user_permissions_per_section(
+    account_password,
     custom_admin_login,
     navigator,
     provider_member_user,
-    all_page_objects,
-    permission,
+    backend_default,
+    user_permission,
+    required_permission,
     page_view,
-    allowed_services=False,
+    is_page_accessible,
 ):
-    """Tests user permissions permission per permission section"""
-    member_user = provider_member_user(allowed_sections=permission, allowed_services=allowed_services)
-    custom_admin_login(member_user.entity_name, "123456")
+    """
+    Tests user permissions permission per permission section
+        - Creates a member user with a specific permission
+        - Logs in as that member user
+        - Attempts to access a specific UI page
+        - If users permission matches page's required permission -> allowed
+        - Else, access denied
+    """
+    member_user = provider_member_user(allowed_sections=[user_permission], allowed_services=None)
+    custom_admin_login(member_user.entity_name, account_password)
 
-    page_objects = all_page_objects(permission, page_view)
+    if page_view == BackendTrafficView:
+        page = navigator.open(page_view, backend=backend_default, wait_displayed=False)
+    else:
+        page = navigator.open(page_view, wait_displayed=False)
 
-    for pg_obj in page_objects:
-        # Dynamically import the view class
-        view_module = __import__(pg_obj.__module__, fromlist=[pg_obj.__name__])
-        page_class = getattr(view_module, pg_obj.__name__)
-        page = navigator.open(page_class, wait_displayed=False)
-
-        if pg_obj == page_view:
-            assert (
-                page.is_displayed
-            ), f"{pg_obj.__name__} should be displayed for permissions {permission} and services {allowed_services}"
-        else:
-            assert AccessDeniedView(navigator.browser.root_browser).is_displayed, (
-                f"{pg_obj.__name__}"
-                f" should not be displayed for permissions {permission} and services {allowed_services}"
-            )
+    if user_permission == required_permission:
+        assert is_page_accessible(page), f"A user with {user_permission} should be able to access {page_view}"
+    else:
+        access_denied_view = AccessDeniedView(navigator.browser.root_browser)
+        assert (
+            access_denied_view.is_displayed
+        ), f"A user with {user_permission} should not be able to access {page_view}"


### PR DESCRIPTION
- Aim is to expand scope of user permissions test
- Logic refactor to enable scope expansion
  - Views/Permissions defined in separate dictionaries 
  - Checks if user has required permission to access particular page
  - If true, expects page to be returned. Else, user access denied
- Broadening test scope: Adding `monitoring`, `plans` and `partners`
- Replacing `page.is_displayed` with less strict test. No longer checks for individual page elements which for some users don't appear, allowing for test scope to be expanded.
