### PR TITLE
Fix pipenv lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ export DOCKERCONFIGJSON
 endif
 
 Pipfile.lock: Pipfile
-	pipenv lock $(PIPENV_ARGS)
+	PIPENV_RESOLVER_PARENT_PYTHON=1 pipenv lock $(PIPENV_ARGS)
 
 .make-pipenv-sync: Pipfile.lock
 	pipenv sync $(PIPENV_ARGS)


### PR DESCRIPTION
Fix for the ```ResolutionFailure``` which is raised after call ```make commit-acceptance``` when the ```Pipfile``` was modified.

It seems that without ```PIPENV_RESOLVER_PARENT_PYTHON=1``` pipenv may use different version of Python for the resolver subprocess, which causes failure.