### PR TITLE
Widgetastic's TextInput.fill() Failing For `test_edit_tenant`

### DIFF
--- a/testsuite/tests/apicast_operator/test_user_env_var.py
+++ b/testsuite/tests/apicast_operator/test_user_env_var.py
@@ -1,0 +1,58 @@
+"""
+Test that user defined environment variables persist through APIcast operator reconciliation.
+
+This test validates the fix for THREESCALE-12224.
+"""
+
+import pytest
+from packaging.version import Version
+
+from testsuite import TESTED_VERSION
+from testsuite.capabilities import Capability
+
+pytestmark = [
+    pytest.mark.sandbag,  # Test uses operator, is slow
+    pytest.mark.issue("https://issues.redhat.com/browse/THREESCALE-12224"),
+    pytest.mark.required_capabilities(Capability.OCP4),
+    pytest.mark.skipif(TESTED_VERSION < Version("2.16.4"), reason="TESTED_VERSION < Version('2.16.4')"),
+]
+
+
+@pytest.fixture(scope="module")
+def gw_with_user_env(staging_gateway, logger):
+    """
+    Adds environment variables to the APIcast deployment.
+    """
+
+    test_env_var_name = "APICAST_PATH_ROUTING_ONLY"
+    test_env_var_value = "true"
+
+    environ = staging_gateway.deployment.environ()
+    environ.refresh()
+
+    logger.info("Adding env var: %s=%s", test_env_var_name, test_env_var_value)
+    environ[test_env_var_name] = test_env_var_value
+
+    environ.refresh()
+    assert environ[test_env_var_name] == test_env_var_value, "Env var was not set correctly"
+
+    return environ, test_env_var_name, test_env_var_value
+
+
+def test_user_env_var_persists(gw_with_user_env, staging_gateway):
+    """Verify user defined vars remain after reconciliation"""
+    environ, test_env_var_name, test_env_var_value = gw_with_user_env
+
+    # Trigger reconciliation by modifying a supported env var that goes through the operator
+    staging_gateway.environ["APICAST_LOG_LEVEL"] = "debug"
+    staging_gateway.deployment.wait_for()
+
+    environ.refresh()
+
+    try:
+        current_value = environ[test_env_var_name]
+        assert (
+            current_value == test_env_var_value
+        ), f"Env var changed after reconciliation. Expected: {test_env_var_value}, got {current_value}"
+    except KeyError:
+        pytest.fail(f"FAILURE: User-defined env var '{test_env_var_name}' was removed during operator reconciliation.")

--- a/testsuite/tests/ui/master/test_tenant.py
+++ b/testsuite/tests/ui/master/test_tenant.py
@@ -72,7 +72,7 @@ def test_edit_tenant(navigator, tenant, master_threescale, request):
     edit = navigator.navigate(TenantEditView, account=account)
 
     updated_name = blame(request, "updated_name")
-    edit.update(org_name=updated_name)
+    edit.replace(org_name=updated_name)
     account = master_threescale.accounts.read(account_id)
 
     assert account.entity_name != old_name

--- a/testsuite/ui/views/master/audience/tenant.py
+++ b/testsuite/ui/views/master/audience/tenant.py
@@ -162,6 +162,12 @@ class TenantEditView(BaseMasterAudienceView):
     def __init__(self, parent, account):
         super().__init__(parent, account_id=account.entity_id)
 
+    def replace(self, org_name: str):
+        """Update account"""
+        self.browser.element(self.org_name).clear()
+        self.org_name.fill(org_name)
+        self.update_button.click()
+
     def update(self, org_name: str):
         """Update account"""
         self.org_name.fill(org_name)


### PR DESCRIPTION
- Widgetastic's `TextInput.fill()` method is appending text instead of replacing the existing value in the input field, even though it's supposed to clear and replace by default. This is causing `test_edit_tenant` to fail persistently. 
- A `replace()` method has been added to tenant.py, alongside the existing `update()` method
- The `replace()` accessed the element directly through selenium and forces `self.org_name` to clear before updating it, which resolves the failure