### PR TITLE
Fix upstream+url_rewriting test to use distinct backends and discover…

### DIFF
--- a/testsuite/tests/apicast/policy/test_upstream_url_rewriting_policy.py
+++ b/testsuite/tests/apicast/policy/test_upstream_url_rewriting_policy.py
@@ -11,8 +11,22 @@ from testsuite.echoed_request import EchoedRequest
 
 
 @pytest.fixture(scope="module")
-def service(service, private_base_url):
+def upstream_url_one(private_base_url):
+    """URL of the echo_api backend used as upstream for v1 rule"""
+    return private_base_url("echo_api")
+
+
+@pytest.fixture(scope="module")
+def upstream_url_two(private_base_url):
+    """URL of the httpbin backend used as upstream for v2 rule"""
+    return private_base_url("httpbin")
+
+
+@pytest.fixture(scope="module")
+def service(service, upstream_url_one, upstream_url_two):
     """Add url_rewriting policy, configure metrics/mapping"""
+    assert upstream_url_one != upstream_url_two, "Upstream rules must use different backends to verify routing"
+
     proxy = service.proxy.list()
     proxy.policies.insert(
         0,
@@ -20,8 +34,8 @@ def service(service, private_base_url):
             "upstream",
             {
                 "rules": [
-                    {"url": private_base_url("echo_api"), "regex": "v1"},
-                    {"url": private_base_url(), "regex": "v2"},
+                    {"url": upstream_url_one, "regex": "v1"},
+                    {"url": upstream_url_two, "regex": "v2"},
                 ]
             },
         ),
@@ -47,27 +61,24 @@ def service(service, private_base_url):
     return service
 
 
-def test_url_rewriting_policy_v1(api_client, private_base_url):
+def test_url_rewriting_policy_v1(api_client, upstream_url_one):
     """must rewrite /httpbin/v1 to /rewrite and get response from new domain echo-api.3scale.net"""
-    parsed_url = urlparse(private_base_url("echo_api"))
+    parsed_url = urlparse(upstream_url_one)
     request = EchoedRequest.create(api_client().get("/httpbin/v1"))
     assert request.path == "/rewrite"
-    # X-Forwarded- can contain more values
-    forwarded_hosts = [h.strip() for h in request.headers["X-Forwarded-Host"].split(",")]
-    assert any(h in (parsed_url.hostname, parsed_url.netloc) for h in forwarded_hosts)
-    assert "443" in request.headers["X-Forwarded-Port"]
-    assert "https" in request.headers["X-Forwarded-Proto"]
+    assert request.headers["Host"] in (parsed_url.hostname, parsed_url.netloc)
 
 
-def test_url_rewriting_policy_v2(api_client, application, private_base_url):
+def test_url_rewriting_policy_v2(api_client, application, upstream_url_two):
     """must rewrite /httpbin/v2 to /get and provide response from new domain httpbin"""
-    parsed_url = urlparse(private_base_url())
+    parsed_url = urlparse(upstream_url_two)
     analytics = application.threescale_client.analytics
     old_usage = analytics.list_by_service(application["service_id"], metric_name="hits")["total"]
-    response = api_client().get("/anything/anything")
+    response = api_client().get("/httpbin/v2")
     assert response.status_code == 200
 
     request = EchoedRequest.create(response)
+    assert request.path == "/get"
     assert request.headers["Host"] in (parsed_url.hostname, parsed_url.netloc)
 
     hits = resilient.analytics_list_by_service(


### PR DESCRIPTION
…ed URLs

- Use separate echo_api and httpbin backends so the upstream policy routing can be verified alongside url_rewriting
- Assert backends differ to fail explicitly if they resolve to the same URL
- Fix test_v2 to send to /httpbin/v2 and assert the rewrite to /get
- Extract backend URLs into upstream_url_one/two fixtures

Replace X-Forwarded-Host assertion with Host header check. The original test checked X-Forwarded-Host for the upstream backend hostname, but that only worked because the OCP router (HAProxy) appends the route hostname to X-Forwarded-Host as requests pass through. With external backends (no OCP router in the path), X-Forwarded-Host only contains the gateway hostname set by apicast. The Host header is set by apicast to the upstream target in both cases and is the correct header to verify routing.