### PR TITLE
[stable-2.15] Fix wait_for 2.0 compatibility for UI tests

### DIFF
--- a/testsuite/tests/ui/conftest.py
+++ b/testsuite/tests/ui/conftest.py
@@ -6,11 +6,13 @@ import io
 import logging
 import math
 import os
+import re
 from datetime import datetime
 
 import backoff
 import pytest
 import pytest_html
+import wait_for
 from auth0.management import Auth0
 from selenium.common import InvalidSessionIdException, WebDriverException
 from threescale_api.errors import ApiClientError
@@ -37,6 +39,22 @@ from testsuite.ui.webdriver import ThreescaleWebdriver
 from testsuite.utils import blame, get_results_dir_path
 
 LOGGER = logging.getLogger(__name__)
+
+# Patch wait_for 2.0 to accept string timeouts (e.g. "15s") for backwards compatibility with widgetastic
+_original_get_timeout_secs = wait_for._get_timeout_secs  # pylint: disable=protected-access
+
+
+def _patched_get_timeout_secs(kwargs):
+    """Parse string timeouts like '15s' into integers"""
+    timeout = kwargs.get("timeout", None)
+    if isinstance(timeout, str):
+        match = re.match(r"^(\d+)\s*s$", timeout)
+        if match:
+            kwargs["timeout"] = int(match.group(1))
+    return _original_get_timeout_secs(kwargs)
+
+
+wait_for._get_timeout_secs = _patched_get_timeout_secs  # pylint: disable=protected-access
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
wait_for 2.0 dropped support for string timeouts (e.g. 15s), breaking widgetastic which passes them internally. Add a monkey patch in UI conftest to parse string timeouts back to integers.

https://github.com/RedHatQE/wait_for/pull/46
(cherry picked from commit 8bbc07313d88525c947a8e99e16bc1ccf84eb1fe)