### PR TITLE
Remove deprecated event_loop fixture for pytest-asyncio 1.x compatibi…

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -25,6 +25,7 @@ junit_logging=all
 junit_family=xunit2
 junit_log_passing_tests=0
 asyncio_mode=auto
+asyncio_default_fixture_loop_scope=module
 addopts = --last-failed-no-failures=none
 
 #addopts = --pdbcls=IPython.terminal.debugger:Pdb

--- a/testsuite/tests/apicast/parameters/test_apicast_pagination.py
+++ b/testsuite/tests/apicast/parameters/test_apicast_pagination.py
@@ -10,9 +10,7 @@ from testsuite.utils import blame
 
 # pylint: disable=too-many-arguments
 @pytest.fixture(autouse=True)
-async def many_services(
-    request, event_loop, custom_service, service_proxy_settings, lifecycle_hooks, custom_backend, testconfig
-):
+async def many_services(request, custom_service, service_proxy_settings, lifecycle_hooks, custom_backend, testconfig):
     """Creation of 500+ services"""
     backend_mapping = {"/": custom_backend("backend")}
 
@@ -21,11 +19,18 @@ async def many_services(
         custom_service(params, service_proxy_settings, backend_mapping, autoclean=False, hooks=lifecycle_hooks)
 
     if not testconfig["skip_cleanup"]:
-        request.addfinalizer(
-            lambda: event_loop.run_until_complete(
-                asyncio.gather(*(asyncio.to_thread(finalizer) for finalizer in custom_service.orphan_finalizers))
-            )
-        )
+
+        def _cleanup():
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(
+                    asyncio.gather(*(loop.run_in_executor(None, f) for f in custom_service.orphan_finalizers))
+                )
+            finally:
+                loop.run_until_complete(loop.shutdown_default_executor())
+                loop.close()
+
+        request.addfinalizer(_cleanup)
 
     return await asyncio.gather(*(asyncio.to_thread(_create_services) for _ in range(505)))
 

--- a/testsuite/tests/performance/conftest.py
+++ b/testsuite/tests/performance/conftest.py
@@ -4,7 +4,6 @@ Conftest for performance tests
 
 import asyncio
 import os
-from concurrent.futures.thread import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -73,18 +72,7 @@ def shared_template(testconfig, number_of_agents):
 
 
 @pytest.fixture(scope="module")
-def event_loop():
-    """Event loop for use in performance tests"""
-    with ThreadPoolExecutor() as pool:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.set_default_executor(pool)
-        yield loop
-        loop.close()
-
-
-@pytest.fixture(scope="module")
-async def applications(services, custom_application, lifecycle_hooks, number_of_apps, event_loop):
+async def applications(services, custom_application, lifecycle_hooks, number_of_apps):
     """Create multiple application for each service"""
 
     def _create_apps(svc):
@@ -92,7 +80,7 @@ async def applications(services, custom_application, lifecycle_hooks, number_of_
         return custom_application(rawobj.Application(randomize("App"), plan), hooks=lifecycle_hooks)
 
     return await asyncio.gather(
-        *(event_loop.run_in_executor(None, _create_apps, svc) for _ in range(number_of_apps) for svc in services)
+        *(asyncio.to_thread(_create_apps, svc) for _ in range(number_of_apps) for svc in services)
     )
 
 
@@ -104,7 +92,6 @@ async def services(
     custom_service,
     custom_app_plan,
     number_of_products,
-    event_loop,
     number_of_backends,
     service_proxy_settings,
     service_settings,
@@ -122,9 +109,7 @@ async def services(
         custom_app_plan(rawobj.ApplicationPlan(randomize("AppPlan")), svc)
         return svc
 
-    return await asyncio.gather(
-        *(event_loop.run_in_executor(None, _create_services) for _ in range(number_of_products))
-    )
+    return await asyncio.gather(*(asyncio.to_thread(_create_services) for _ in range(number_of_products)))
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/performance/rhoam/test_rhoam_multiple_20m.py
+++ b/testsuite/tests/performance/rhoam/test_rhoam_multiple_20m.py
@@ -4,7 +4,6 @@ Performance test for managed services with multiple 3scale entities (products, b
 
 import asyncio
 import os
-from concurrent.futures.thread import ThreadPoolExecutor
 from urllib.parse import urlparse
 
 import backoff
@@ -77,26 +76,23 @@ def create_mapping_rules():
 
 
 @pytest.fixture(scope="module")
-def services(services, create_mapping_rules):
+async def services(services, create_mapping_rules):
     """
     Removes default mapping rule of each product.
     For each backend creates 10 mapping rules
     """
-    loop = asyncio.get_event_loop()
     for svc in services:
         proxy = svc.proxy.list()
         proxy.mapping_rules.delete(proxy.mapping_rules.list()[0]["id"])
-    with ThreadPoolExecutor() as pool:
-        for svc in services:
-            proxy = svc.proxy.list()
-            futures = []
-            for be_usage in svc.backend_usages.list():
-                futures += [
-                    loop.run_in_executor(pool, create_mapping_rules, i, be_usage)
-                    for i in range(NUMBER_OF_MAPPING_RULES_PER_BACKEND)
-                ]
-            loop.run_until_complete(asyncio.gather(*futures))
-            proxy.update()
+    for svc in services:
+        proxy = svc.proxy.list()
+        futures = []
+        for be_usage in svc.backend_usages.list():
+            futures += [
+                asyncio.to_thread(create_mapping_rules, i, be_usage) for i in range(NUMBER_OF_MAPPING_RULES_PER_BACKEND)
+            ]
+        await asyncio.gather(*futures)
+        proxy.update()
     return services
 
 

--- a/testsuite/tests/performance/smoke/test_smoke_app_id_query.py
+++ b/testsuite/tests/performance/smoke/test_smoke_app_id_query.py
@@ -63,7 +63,7 @@ def service_settings(service_settings):
 
 
 @pytest.fixture(scope="module")
-async def services(services, create_mapping_rules, event_loop):
+async def services(services, create_mapping_rules):
     """
     Removes default mapping rule of each product.
     For each backend creates 20 mapping rules
@@ -75,7 +75,7 @@ async def services(services, create_mapping_rules, event_loop):
         proxy = svc.proxy.list()
         futures = []
         for be_usage in svc.backend_usages.list():
-            futures += [event_loop.run_in_executor(None, create_mapping_rules, i, be_usage) for i in range(10)]
+            futures += [asyncio.to_thread(create_mapping_rules, i, be_usage) for i in range(10)]
         await asyncio.gather(*futures)
         proxy.deploy()
     return services

--- a/testsuite/tests/performance/smoke/test_smoke_user_key_query.py
+++ b/testsuite/tests/performance/smoke/test_smoke_user_key_query.py
@@ -53,7 +53,7 @@ def create_mapping_rules():
 
 
 @pytest.fixture(scope="module")
-async def services(services, create_mapping_rules, event_loop):
+async def services(services, create_mapping_rules):
     """
     Removes default mapping rule of each product.
     For each backend creates 20 mapping rules
@@ -65,7 +65,7 @@ async def services(services, create_mapping_rules, event_loop):
         proxy = svc.proxy.list()
         futures = []
         for be_usage in svc.backend_usages.list():
-            futures += [event_loop.run_in_executor(None, create_mapping_rules, i, be_usage) for i in range(10)]
+            futures += [asyncio.to_thread(create_mapping_rules, i, be_usage) for i in range(10)]
         await asyncio.gather(*futures)
         proxy.deploy()
     return services


### PR DESCRIPTION
…lity

The event_loop fixture was removed in pytest-asyncio 1.0. Replace all usages with asyncio.to_thread() and loop.run_in_executor() which are the modern equivalents for running sync code in async fixtures.