### PR TITLE
ci: use pull_request_target to access secrets from fork PRs

### DIFF
--- a/.github/workflows/stable_create_backport_prs.yaml
+++ b/.github/workflows/stable_create_backport_prs.yaml
@@ -6,7 +6,7 @@ name: stable_create_backport_prs
 # The label format must be exactly "backport-to-X.Y" (e.g. backport-to-2.15).
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed, labeled]
     branches:
       - main


### PR DESCRIPTION
pull_request events from forks do not have access to repository secrets, causing the backport workflow to fail with: "Input required and not supplied: token".

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
