### PR TITLE
ci: fix duplicate acceptance runs and drop label from backport PRs

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,6 +1,9 @@
 name: acceptance
 on:
   push:
+    branches:
+      - main
+      - 'stable-*'
   pull_request:
     branches:
       - main

--- a/.github/workflows/stable_create_backport_prs.yaml
+++ b/.github/workflows/stable_create_backport_prs.yaml
@@ -147,11 +147,9 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           BACKPORT_BRANCH: ${{ steps.push.outputs.backport_branch }}
-          LABEL: ${{ matrix.label }}
         run: |
           gh pr create \
             --base  "$TARGET" \
             --head  "$BACKPORT_BRANCH" \
             --title "[backport $TARGET] $PR_TITLE" \
             --body  "Backport of #${PR_NUMBER} to \`${TARGET}\`." \
-            --label "$LABEL"


### PR DESCRIPTION
Add branch filter to acceptance push trigger to prevent duplicate runs on PRs. Remove --label from backport PR creation to avoid re-triggering the backport workflow.